### PR TITLE
KB-11624 | BE | DEV | API for Creating consent acknowledgement and reading the consent details.

### DIFF
--- a/src/main/java/com/igot/cb/cassandra/CassandraOperation.java
+++ b/src/main/java/com/igot/cb/cassandra/CassandraOperation.java
@@ -34,4 +34,22 @@ public interface CassandraOperation {
 
     public void deleteRecord(String keyspaceName, String tableName, Map<String, Object> keyMap);
 
+    /**
+     * Inserts a record into Cassandra with a composite primary key.
+     *
+     * @param keyspaceName      The name of the keyspace containing the table.
+     * @param tableName         The name of the table into which to insert the record.
+     * @param primaryKeyColumn  The name of the primary key column.
+     * @param primaryKeyValue   The value of the primary key.
+     * @param compositeKey      A map representing the composite key fields and their values.
+     * @param otherFields       A map representing other fields and their values to be inserted.
+     * @return An object representing the result of the insertion operation.
+     */
+    Object insertRecord(
+            String keyspaceName,
+            String tableName,
+            String primaryKeyColumn,
+            String primaryKeyValue,
+            Map<String, Object> compositeKey,
+            Map<String, Object> otherFields);
 }

--- a/src/main/java/com/igot/cb/cassandra/CassandraOperationImpl.java
+++ b/src/main/java/com/igot/cb/cassandra/CassandraOperationImpl.java
@@ -225,9 +225,10 @@ public class CassandraOperationImpl implements CassandraOperation {
             }
             String query = CassandraUtil.getPreparedStatement(keyspaceName, tableName, request);
             CqlSession session = connectionManager.getSession(keyspaceName);
-            PreparedStatement statement = session.prepare(query);
-            BoundStatement boundStatement = statement.bind(request.values().toArray());
-            session.execute(boundStatement);
+            SimpleStatement simpleStatement = SimpleStatement.builder(query)
+                    .addPositionalValues(request.values())
+                    .build();
+            session.execute(simpleStatement);
             response.put(Constants.RESPONSE, Constants.SUCCESS);
         } catch (Exception e) {
             String errMsg = String.format(

--- a/src/main/java/com/igot/cb/cassandra/CassandraOperationImpl.java
+++ b/src/main/java/com/igot/cb/cassandra/CassandraOperationImpl.java
@@ -5,7 +5,6 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.*;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import com.datastax.oss.driver.api.querybuilder.delete.Delete;
-import com.datastax.oss.driver.api.querybuilder.delete.DeleteSelection;
 import com.datastax.oss.driver.api.querybuilder.relation.Relation;
 import com.datastax.oss.driver.api.querybuilder.select.Select;
 import com.datastax.oss.driver.api.querybuilder.term.Term;
@@ -19,14 +18,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.text.MessageFormat;
 import java.util.*;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 
@@ -197,6 +192,52 @@ public class CassandraOperationImpl implements CassandraOperation {
                     Constants.EXCEPTION_MSG_DELETE, tableName, e.getMessage()));
             throw e;
         }
+    }
+
+    /**
+     * Inserts a record into Cassandra with a composite primary key.
+     *
+     * @param keyspaceName     The name of the keyspace containing the table.
+     * @param tableName        The name of the table into which to insert the record.
+     * @param primaryKeyColumn The name of the primary key column.
+     * @param primaryKeyValue  The value of the primary key.
+     * @param compositeKey     A map representing the composite key fields and their values.
+     * @param otherFields      A map representing other fields and their values to be inserted.
+     * @return An object representing the result of the insertion operation.
+     */
+    @Override
+    public Object insertRecord(
+            String keyspaceName,
+            String tableName,
+            String primaryKeyColumn,
+            String primaryKeyValue,
+            Map<String, Object> compositeKey,
+            Map<String, Object> otherFields) {
+        ApiResponse response = new ApiResponse();
+        try {
+            Map<String, Object> request = new LinkedHashMap<>();
+            request.put(primaryKeyColumn, primaryKeyValue);
+            if (MapUtils.isNotEmpty(compositeKey)) {
+                request.putAll(compositeKey);
+            }
+            if (MapUtils.isNotEmpty(otherFields)) {
+                request.putAll(otherFields);
+            }
+            String query = CassandraUtil.getPreparedStatement(keyspaceName, tableName, request);
+            CqlSession session = connectionManager.getSession(keyspaceName);
+            PreparedStatement statement = session.prepare(query);
+            BoundStatement boundStatement = statement.bind(request.values().toArray());
+            session.execute(boundStatement);
+            response.put(Constants.RESPONSE, Constants.SUCCESS);
+        } catch (Exception e) {
+            String errMsg = String.format(
+                    "Exception occurred while inserting record into %s. Error: %s",
+                    tableName, e.getMessage());
+            log.error("Error inserting record into {}: {}", tableName, e.getMessage(), e);
+            response.put(Constants.RESPONSE, Constants.FAILED);
+            response.put(Constants.ERROR_MESSAGE, errMsg);
+        }
+        return response;
     }
 
 }

--- a/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeController.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/consent")
+@RequestMapping("/v1/consent")
 public class ConsentAcknowledgeController {
 
     private final IConsentAcknowledgeService acknowledgeService;

--- a/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeController.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeController.java
@@ -1,0 +1,36 @@
+package com.igot.cb.consentacknowledge;
+
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.Constants;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/consent")
+public class ConsentAcknowledgeController {
+
+    private final IConsentAcknowledgeService acknowledgeService;
+
+    public ConsentAcknowledgeController(IConsentAcknowledgeService acknowledgeService) {
+        this.acknowledgeService = acknowledgeService;
+    }
+
+    @PostMapping("/acknowledge")
+    public ResponseEntity<ApiResponse> acknowledgeDeclaration(
+            @RequestHeader(value = Constants.X_AUTH_TOKEN) String authToken,
+            @RequestBody Map<String, Object> request) {
+        ApiResponse response = acknowledgeService.acknowledgeDeclaration(request, authToken);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+
+    @GetMapping("/details/{consentId}")
+    public ResponseEntity<ApiResponse> getConsentDetails(@PathVariable String consentId,
+                                         @RequestHeader(value = Constants.X_AUTH_TOKEN) String authToken) {
+        ApiResponse response = acknowledgeService.getConsentDetails(consentId, authToken);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+}

--- a/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeController.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeController.java
@@ -33,4 +33,13 @@ public class ConsentAcknowledgeController {
         return new ResponseEntity<>(response, response.getResponseCode());
     }
 
+
+    @GetMapping("/acknowledge/read/{contentId}/{consentId}")
+    public ResponseEntity<ApiResponse> getConsentAcknowledgementDetails(@PathVariable(Constants.CONSENT_ID) String consentId,
+                                                                        @PathVariable(Constants.CONTENT_ID) String contentId,
+                                                                        @RequestHeader(value = Constants.X_AUTH_TOKEN) String authToken) {
+        ApiResponse response = acknowledgeService.getConsentAcknowledgementDetails(contentId, consentId, authToken);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
 }

--- a/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImpl.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImpl.java
@@ -88,10 +88,12 @@ public class ConsentAcknowledgeServiceImpl implements IConsentAcknowledgeService
         response.getParams().setStatus(Constants.OK);
         response.setResponseCode(HttpStatus.OK);
         Map<String, Object> result = new HashMap<>();
-        result.put(Constants.RESPONSE, "Declaration acknowledged successfully");
-        result.put(Constants.CONSENT_ID, consentId);
-        result.put(Constants.USER_ID, userId);
-        result.put(Constants.CONTENT_ID, contentId);
+        Map<String, Object> consentAckDetailsMap = new HashMap<>();
+        consentAckDetailsMap.put(Constants.CONTENT_ID, contentId);
+        consentAckDetailsMap.put(Constants.CONSENT_ID, consentId);
+        consentAckDetailsMap.put(Constants.USER_ID, userId);
+        consentAckDetailsMap.put(Constants.MESSAGE,  "Declaration acknowledged successfully");
+        result.put(Constants.RESPONSE,consentAckDetailsMap);
         response.getResult().putAll(result);
         return response;
     }

--- a/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImpl.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.igot.cb.consentacknowledge;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.cassandra.CassandraOperation;
 import com.igot.cb.model.ApiResponse;
@@ -159,6 +160,50 @@ public class ConsentAcknowledgeServiceImpl implements IConsentAcknowledgeService
         response.setResponseCode(HttpStatus.OK);
         Map<String, Object> result = new HashMap<>();
         result.put(Constants.RESPONSE, consentDetailsMap);
+        response.getResult().putAll(result);
+        return response;
+    }
+
+
+    /**
+     * Method to get consent acknowledgement details by contentId and consentId
+     */
+    @Override
+    public ApiResponse getConsentAcknowledgementDetails(String contentId, String consentId, String authToken) {
+        ApiResponse response = ProjectUtil.createDefaultResponse("api.consent.acknowledgement.read");
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authToken, response);
+        if (StringUtils.isEmpty(userId)) {
+            return response;
+        }
+        Map<String, Object> propertyMap = new HashMap<>();
+        propertyMap.put(Constants.CONSENT_ID, consentId);
+        propertyMap.put(Constants.CONTENT_ID, contentId);
+        propertyMap.put(Constants.USER_ID, userId);
+        List<Map<String, Object>> consentAcknowledgementDetailsList;
+        try {
+            consentAcknowledgementDetailsList = cassandraOperation
+                    .getRecordsByProperties(Constants.KEYSPACE_SUNBIRD, Constants.TABLE_DECLARATION_ACKNOWLEDGMENT, propertyMap, Arrays.asList(Constants.CONTENT_ID, Constants.CONSENT_ID, Constants.USER_ID, Constants.ADDITIONAL_ATTRIBUTES), null);
+        } catch (Exception e) {
+            logger.error("Error while fetching consent details from DB", e);
+            ProjectUtil.errorResponse(response, "Failed to fetch consent Acknowledgement details. Please try again later.", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response;
+        }
+        Map<String, Object> consentAcknowledgementDetailsMap = consentAcknowledgementDetailsList.get(0);
+        String additionAttributesStr = (String) consentAcknowledgementDetailsMap.get(Constants.ADDITIONAL_ATTRIBUTES);
+        Map<String, Object> additionalAttributesMap = null;
+        try {
+            additionalAttributesMap = objectMapper.readValue(additionAttributesStr, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            logger.error("Error while parsing additionalAttributes from string to map", e);
+            ProjectUtil.errorResponse(response, "Failed to Parse the additional attributes", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response;
+        }
+        consentAcknowledgementDetailsMap.put(Constants.ADDITIONAL_ATTRIBUTES, additionalAttributesMap);
+        response.getParams().setStatus(Constants.OK);
+        response.setResponseCode(HttpStatus.OK);
+        Map<String, Object> result = new HashMap<>();
+        result.put(Constants.RESPONSE, consentAcknowledgementDetailsMap);
         response.getResult().putAll(result);
         return response;
     }

--- a/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImpl.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImpl.java
@@ -1,0 +1,153 @@
+package com.igot.cb.consentacknowledge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.AccessTokenValidator;
+import com.igot.cb.util.Constants;
+import com.igot.cb.util.ProjectUtil;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ConsentAcknowledgeServiceImpl implements IConsentAcknowledgeService {
+
+    private final Logger logger = LoggerFactory.getLogger(ConsentAcknowledgeServiceImpl.class);
+
+
+    private final AccessTokenValidator accessTokenValidator;
+    private final CassandraOperation cassandraOperation;
+    private final ObjectMapper objectMapper;
+
+    public ConsentAcknowledgeServiceImpl(AccessTokenValidator accessTokenValidator, CassandraOperation cassandraOperation, ObjectMapper objectMapper) {
+        this.cassandraOperation = cassandraOperation;
+        this.accessTokenValidator = accessTokenValidator;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Method to acknowledge declaration
+     * Required fields in request body : contentId, consentId
+     * Optional fields in request body : additionalData
+     */
+    @Override
+    public ApiResponse acknowledgeDeclaration(Map<String, Object> requestDataBody, String authToken) {
+        ApiResponse response = ProjectUtil.createDefaultResponse("api.consent.acknowledge.create");
+        Map<String, Object> requestDataMap = (Map<String, Object>) requestDataBody.get(Constants.REQUEST);
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authToken, response);
+        if (StringUtils.isEmpty(userId)) {
+            return response;
+        }
+        String errMsg = validateAcknowledgeDeclarationRequest(requestDataMap);
+        if (!StringUtils.isEmpty(errMsg)) {
+            ProjectUtil.errorResponse(response, errMsg, HttpStatus.BAD_REQUEST);
+            return response;
+        }
+        String contentId = (String) requestDataMap.get(Constants.CONTENT_ID);
+        String consentId = (String) requestDataMap.get(Constants.CONSENT_ID);
+        Map<String, Object> additionalData = (Map<String, Object>) requestDataMap.get(Constants.ADDITIONAL_ATTRIBUTES);
+        String additionalDataStr = null;
+        try {
+            additionalDataStr = objectMapper.writeValueAsString(additionalData);
+        } catch (JsonProcessingException e) {
+            logger.error("Error while converting additionalData to string", e);
+            ProjectUtil.errorResponse(response,"Failed to Parse the additional attributes", HttpStatus.BAD_REQUEST);
+            return response;
+        }
+        Map<String, Object> compositeKeyMap = new HashMap<>();
+        compositeKeyMap.put(Constants.USER_ID, userId);
+        compositeKeyMap.put(Constants.CONSENT_ID, consentId);
+        Map<String, Object> declarationDataMap = new HashMap<>();
+        ZoneId zoneId = ZoneId.of("Asia/Kolkata");
+        ZonedDateTime submittedAt = ZonedDateTime.ofInstant(Instant.now(), zoneId);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+        declarationDataMap.put(Constants.SUBMITTED_BY, userId);
+        declarationDataMap.put(Constants.ADDITIONAL_ATTRIBUTES, additionalDataStr);
+        declarationDataMap.put(Constants.SUBMITTED_AT, submittedAt.format(formatter));
+        try {
+            cassandraOperation.insertRecord(Constants.KEYSPACE_SUNBIRD, Constants.TABLE_DECLARATION_ACKNOWLEDGMENT, Constants.CONTENT_ID, contentId, compositeKeyMap, declarationDataMap);
+        } catch (Exception e) {
+            logger.error("Error while inserting declaration acknowledgment record in DB", e);
+            ProjectUtil.errorResponse(response, "Failed to acknowledge declaration. Please try again later.", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response;
+        }
+        response.getParams().setStatus(Constants.OK);
+        response.setResponseCode(HttpStatus.OK);
+        Map<String, Object> result = new HashMap<>();
+        result.put(Constants.RESPONSE, "Declaration acknowledged successfully");
+        result.put(Constants.CONSENT_ID, consentId);
+        result.put(Constants.USER_ID, userId);
+        result.put(Constants.CONTENT_ID, contentId);
+        response.getResult().putAll(result);
+        return response;
+    }
+
+    /**
+     * Method to validate acknowledge declaration request
+     */
+    private String validateAcknowledgeDeclarationRequest(Map<String, Object> requestData) {
+        if (requestData == null) {
+            return "Request data is missing.";
+        }
+        if (!requestData.containsKey(Constants.CONTENT_ID)
+                || StringUtils.isEmpty(requestData.get(Constants.CONTENT_ID).toString())) {
+            return "Missing or invalid contentId.";
+        }
+        if (!requestData.containsKey(Constants.CONSENT_ID)
+                || StringUtils.isEmpty(requestData.get(Constants.CONSENT_ID).toString())) {
+            return "Missing or invalid consentId.";
+        }
+        if (requestData.containsKey(Constants.ADDITIONAL_ATTRIBUTES)) {
+            Map<String, Object> additionalData = (Map<String, Object>) requestData.get(Constants.ADDITIONAL_ATTRIBUTES);
+            if (MapUtils.isEmpty(additionalData)) {
+                return "Missing or invalid additionalData.";
+            }
+        }
+        return "";
+    }
+
+
+    /**
+     * Method to get consent details by consentId
+     */
+    @Override
+    public ApiResponse getConsentDetails(String consentId, String authToken) {
+        ApiResponse response = ProjectUtil.createDefaultResponse("api.consent.read");
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authToken, response);
+        if (StringUtils.isEmpty(userId)) {
+            return response;
+        }
+        Map<String, Object> propertyMap = new HashMap<>();
+        propertyMap.put(Constants.CONSENT_ID, consentId);
+        List<Map<String, Object>> consentDetails;
+        try {
+            consentDetails = cassandraOperation
+                    .getRecordsByProperties(Constants.KEYSPACE_SUNBIRD, Constants.TABLE_CONSENT_DETAILS, propertyMap, Arrays.asList(Constants.CONSENT_ID, Constants.ADDITIONAL_DATA, Constants.DESCRIPTION), null);
+        } catch (Exception e) {
+            logger.error("Error while fetching consent details from DB", e);
+            ProjectUtil.errorResponse(response, "Failed to fetch consent details. Please try again later.", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response;
+        }
+        Map<String, Object> consentDetailsMap = consentDetails.get(0);
+        response.getParams().setStatus(Constants.OK);
+        response.setResponseCode(HttpStatus.OK);
+        Map<String, Object> result = new HashMap<>();
+        result.put(Constants.RESPONSE, consentDetailsMap);
+        response.getResult().putAll(result);
+        return response;
+    }
+}

--- a/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImpl.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImpl.java
@@ -79,7 +79,17 @@ public class ConsentAcknowledgeServiceImpl implements IConsentAcknowledgeService
         declarationDataMap.put(Constants.ADDITIONAL_ATTRIBUTES, additionalDataStr);
         declarationDataMap.put(Constants.SUBMITTED_AT, submittedAt.format(formatter));
         try {
-            cassandraOperation.insertRecord(Constants.KEYSPACE_SUNBIRD, Constants.TABLE_DECLARATION_ACKNOWLEDGMENT, Constants.CONTENT_ID, contentId, compositeKeyMap, declarationDataMap);
+            response = (ApiResponse) cassandraOperation.insertRecord(Constants.KEYSPACE_SUNBIRD, Constants.TABLE_DECLARATION_ACKNOWLEDGMENT, Constants.CONTENT_ID, contentId, compositeKeyMap, declarationDataMap);
+            if (Constants.FAILED.equals(response.get(Constants.RESPONSE))) {
+                logger.error("Error while inserting declaration acknowledgment record in DB: {}",
+                        response.get(Constants.ERROR_MESSAGE));
+                ProjectUtil.errorResponse(
+                        response,
+                        "Failed to acknowledge declaration. Please try again later.",
+                        HttpStatus.INTERNAL_SERVER_ERROR
+                );
+                return response;
+            }
         } catch (Exception e) {
             logger.error("Error while inserting declaration acknowledgment record in DB", e);
             ProjectUtil.errorResponse(response, "Failed to acknowledge declaration. Please try again later.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/igot/cb/consentacknowledge/IConsentAcknowledgeService.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/IConsentAcknowledgeService.java
@@ -1,0 +1,26 @@
+package com.igot.cb.consentacknowledge;
+
+import com.igot.cb.model.ApiResponse;
+
+import java.util.Map;
+
+public interface IConsentAcknowledgeService {
+
+    /**
+     * Acknowledge a declaration based on the provided request data and authentication token.
+     *
+     * @param request   A map containing the request data for acknowledging the declaration.
+     * @param authToken The authentication token for validating the request.
+     * @return An ApiResponse object containing the result of the acknowledgment operation.
+     */
+    ApiResponse acknowledgeDeclaration(Map<String, Object> request, String authToken);
+
+    /**
+     * Retrieve consent details based on the provided consent ID and authentication token.
+     *
+     * @param consentId The ID of the consent to retrieve details for.
+     * @param authToken The authentication token for validating the request.
+     * @return An ApiResponse object containing the consent details.
+     */
+    ApiResponse getConsentDetails(String consentId, String authToken);
+}

--- a/src/main/java/com/igot/cb/consentacknowledge/IConsentAcknowledgeService.java
+++ b/src/main/java/com/igot/cb/consentacknowledge/IConsentAcknowledgeService.java
@@ -23,4 +23,15 @@ public interface IConsentAcknowledgeService {
      * @return An ApiResponse object containing the consent details.
      */
     ApiResponse getConsentDetails(String consentId, String authToken);
+
+
+    /**
+     * Retrieve consent acknowledgement details based on the provided content ID, consent ID, and authentication token.
+     *
+     * @param contentId The ID of the content to retrieve details for.
+     * @param consentId The ID of the consent to retrieve details for.
+     * @param authToken The authentication token for validating the request.
+     * @return An ApiResponse object containing the consent acknowledgement details.
+     */
+    ApiResponse getConsentAcknowledgementDetails(String contentId, String consentId, String authToken);
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -413,7 +413,13 @@ public class Constants {
     public static final String X_AUTH_USER_ID = "x-authenticated-userid";
     public static final String IS_CCA = "iscca";
     public static final String ROOT_ORG_IDS_IN_CONTEXT_DATA = "rootOrgIdsInContextData";
-
+    public static final String TABLE_DECLARATION_ACKNOWLEDGMENT = "consent_acknowledgement" ;
+    public static final String TABLE_CONSENT_DETAILS = "consent_details" ;
+    public static final String CONSENT_ID= "consentId";
+    public static final String SUBMITTED_BY = "submittedBy";
+    public static final String SUBMITTED_AT = "submittedAt";
+    public static final String ADDITIONAL_ATTRIBUTES = "additionalAttributes";
+    public static final String ADDITIONAL_DATA = "additionaldata";
     private Constants() {
     }
 }

--- a/src/main/java/com/igot/cb/util/ProjectUtil.java
+++ b/src/main/java/com/igot/cb/util/ProjectUtil.java
@@ -22,6 +22,13 @@ public class ProjectUtil {
         return response;
     }
 
+    public static void errorResponse(ApiResponse response, String errorMessage, HttpStatus httpStatus) {
+        response.setResponseCode(httpStatus);
+        response.getParams().setErrMsg(errorMessage);
+        response.getParams().setStatus(Constants.FAILED);
+    }
+
+
     public static Date getTimeStamp() {
         return new Timestamp(System.currentTimeMillis());
     }

--- a/src/main/resources/cassandratablecolumn.properties
+++ b/src/main/resources/cassandratablecolumn.properties
@@ -25,3 +25,4 @@ orgid=orgId
 assignmenttype=assignmentType
 assignmenttypeinfo=assignmentTypeInfo
 rootorgid=rootOrgId
+additionalattributes=additionalAttributes

--- a/src/test/java/com/igot/cb/cassandra/CassandraOperationImplTest.java
+++ b/src/test/java/com/igot/cb/cassandra/CassandraOperationImplTest.java
@@ -348,4 +348,40 @@ class CassandraOperationImplTest {
             assertEquals(Constants.FAILED, response.get(Constants.RESPONSE));
         }
     }
+
+    @Test
+    void testInsertRecord_Success() {
+        Map<String, Object> compositeKey = Map.of("userId", "u1");
+        Map<String, Object> otherFields = Map.of("field1", "value1");
+        try (MockedStatic<CassandraUtil> mockedCassandraUtil = mockStatic(CassandraUtil.class)) {
+            mockedCassandraUtil.when(() -> CassandraUtil.getPreparedStatement(anyString(), anyString(), any()))
+                    .thenReturn("INSERT INTO table ...");
+            when(connectionManager.getSession("ks")).thenReturn(mockSession);
+            when(mockSession.prepare(anyString())).thenReturn(mockPreparedStatement);
+            when(mockPreparedStatement.bind(any(Object[].class))).thenReturn(mockBoundStatement);
+            Object result = cassandraOperation.insertRecord(
+                    "ks", "tbl", "contentId", "c1", compositeKey, otherFields);
+            assertInstanceOf(ApiResponse.class, result);
+            ApiResponse response = (ApiResponse) result;
+            assertEquals(Constants.SUCCESS, response.get(Constants.RESPONSE));
+        }
+    }
+
+    @Test
+    void testInsertRecord_Failure() {
+        Map<String, Object> compositeKey = new HashMap<>();
+        Map<String, Object> otherFields = new LinkedHashMap<>();
+
+        try (MockedStatic<CassandraUtil> mockedCassandraUtil = mockStatic(CassandraUtil.class)) {
+            mockedCassandraUtil.when(() -> CassandraUtil.getPreparedStatement(anyString(), anyString(), any()))
+                    .thenThrow(new RuntimeException("DB error"));
+            Object result = cassandraOperation.insertRecord(
+                    "ks", "tbl", "contentId", "c1", compositeKey, otherFields);
+            assertInstanceOf(ApiResponse.class, result);
+            ApiResponse response = (ApiResponse) result;
+            assertEquals(Constants.FAILED, response.get(Constants.RESPONSE));
+            assertTrue(response.get(Constants.ERROR_MESSAGE).toString().contains("tbl"));
+            assertTrue(response.get(Constants.ERROR_MESSAGE).toString().contains("DB error"));
+        }
+    }
 }

--- a/src/test/java/com/igot/cb/cassandra/CassandraOperationImplTest.java
+++ b/src/test/java/com/igot/cb/cassandra/CassandraOperationImplTest.java
@@ -354,16 +354,17 @@ class CassandraOperationImplTest {
         Map<String, Object> compositeKey = Map.of("userId", "u1");
         Map<String, Object> otherFields = Map.of("field1", "value1");
         try (MockedStatic<CassandraUtil> mockedCassandraUtil = mockStatic(CassandraUtil.class)) {
-            mockedCassandraUtil.when(() -> CassandraUtil.getPreparedStatement(anyString(), anyString(), any()))
+            mockedCassandraUtil.when(() ->
+                            CassandraUtil.getPreparedStatement(anyString(), anyString(), any()))
                     .thenReturn("INSERT INTO table ...");
             when(connectionManager.getSession("ks")).thenReturn(mockSession);
-            when(mockSession.prepare(anyString())).thenReturn(mockPreparedStatement);
-            when(mockPreparedStatement.bind(any(Object[].class))).thenReturn(mockBoundStatement);
+            when(mockSession.execute(any(SimpleStatement.class))).thenReturn(mock(ResultSet.class));
             Object result = cassandraOperation.insertRecord(
                     "ks", "tbl", "contentId", "c1", compositeKey, otherFields);
             assertInstanceOf(ApiResponse.class, result);
             ApiResponse response = (ApiResponse) result;
             assertEquals(Constants.SUCCESS, response.get(Constants.RESPONSE));
+            verify(mockSession).execute(any(SimpleStatement.class));
         }
     }
 

--- a/src/test/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImplTest.java
+++ b/src/test/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImplTest.java
@@ -43,13 +43,25 @@ class ConsentAcknowledgeServiceImplTest {
         requestData.put(Constants.CONSENT_ID, "consent1");
         requestData.put(Constants.ADDITIONAL_ATTRIBUTES, Map.of("k", "v"));
         Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
-        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
-        when(objectMapper.writeValueAsString(any())).thenReturn("{\"k\":\"v\"}");
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenReturn("user1");
+        when(objectMapper.writeValueAsString(any()))
+                .thenReturn("{\"k\":\"v\"}");
         ApiResponse response = service.acknowledgeDeclaration(body, "token");
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertEquals(Constants.OK, response.getParams().getStatus());
-        assertEquals("Declaration acknowledged successfully", response.getResult().get(Constants.RESPONSE));
-        verify(cassandraOperation, times(1)).insertRecord(any(), any(), any(), any(), any(), any());
+        Map<String, Object> result = response.getResult();
+        assertNotNull(result);
+
+        Map<String, Object> consentAckDetails =
+                (Map<String, Object>) result.get(Constants.RESPONSE);
+        assertNotNull(consentAckDetails);
+        assertEquals("content1", consentAckDetails.get(Constants.CONTENT_ID));
+        assertEquals("consent1", consentAckDetails.get(Constants.CONSENT_ID));
+        assertEquals("user1", consentAckDetails.get(Constants.USER_ID));
+        assertEquals("Declaration acknowledged successfully", consentAckDetails.get(Constants.MESSAGE));
+        verify(cassandraOperation, times(1))
+                .insertRecord(any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImplTest.java
+++ b/src/test/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.igot.cb.consentacknowledge;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.cassandra.CassandraOperation;
 import com.igot.cb.model.ApiResponse;
@@ -345,5 +346,80 @@ class ConsentAcknowledgeServiceImplTest {
             assertEquals("Failed to Parse the additional attributes",
                     response.getParams().getErr());
         }
+    }
+
+    @Test
+    void testGetConsentAcknowledgementDetails_Success() throws Exception {
+        String contentId = "content1";
+        String consentId = "consent1";
+        String authToken = "token";
+        String userId = "user1";
+        when(accessTokenValidator.fetchUserIdFromAccessToken(eq(authToken), any()))
+                .thenReturn(userId);
+        Map<String, Object> dbRecord = new HashMap<>();
+        dbRecord.put(Constants.CONTENT_ID, contentId);
+        dbRecord.put(Constants.CONSENT_ID, consentId);
+        dbRecord.put(Constants.USER_ID, userId);
+        dbRecord.put(Constants.ADDITIONAL_ATTRIBUTES, "{\"k\":\"v\"}");
+        when(cassandraOperation.getRecordsByProperties(
+                any(), any(), any(), any(), isNull()))
+                .thenReturn(List.of(dbRecord));
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenReturn(Map.of("k", "v"));
+        ApiResponse response = service.getConsentAcknowledgementDetails(contentId, consentId, authToken);
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        assertEquals(Constants.OK, response.getParams().getStatus());
+        Map<String, Object> result = response.getResult();
+        assertNotNull(result);
+        Map<String, Object> consentDetails =
+                (Map<String, Object>) result.get(Constants.RESPONSE);
+        assertNotNull(consentDetails);
+        assertEquals(contentId, consentDetails.get(Constants.CONTENT_ID));
+        assertEquals(consentId, consentDetails.get(Constants.CONSENT_ID));
+        assertEquals(userId, consentDetails.get(Constants.USER_ID));
+        assertEquals(Map.of("k", "v"), consentDetails.get(Constants.ADDITIONAL_ATTRIBUTES));
+        verify(cassandraOperation, times(1))
+                .getRecordsByProperties(any(), any(), any(), any(), isNull());
+        verify(objectMapper, times(1))
+                .readValue(anyString(), any(TypeReference.class));
+    }
+
+    @Test
+    void testGetConsentAcknowledgementDetails_EmptyUserId() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenReturn("");
+        ApiResponse response = service.getConsentAcknowledgementDetails("c1", "consent1", "token");
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        verifyNoInteractions(cassandraOperation);
+    }
+
+    @Test
+    void testGetConsentAcknowledgementDetails_DbException() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenReturn("user1");
+        when(cassandraOperation.getRecordsByProperties(any(), any(), any(), any(), any()))
+                .thenThrow(new RuntimeException("DB error"));
+        ApiResponse response = service.getConsentAcknowledgementDetails("c1", "consent1", "token");
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+        assertEquals(Constants.FAILED, response.getParams().getStatus()); 
+    }
+
+    @Test
+    void testGetConsentAcknowledgementDetails_JsonProcessingException() throws Exception {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenReturn("user1");
+        Map<String, Object> dbRecord = new HashMap<>();
+        dbRecord.put(Constants.CONTENT_ID, "c1");
+        dbRecord.put(Constants.CONSENT_ID, "consent1");
+        dbRecord.put(Constants.USER_ID, "user1");
+        dbRecord.put(Constants.ADDITIONAL_ATTRIBUTES, "{\"bad\":json}");
+        when(cassandraOperation.getRecordsByProperties(any(), any(), any(), any(), isNull()))
+                .thenReturn(List.of(dbRecord));
+        when(objectMapper.readValue(anyString(), any(TypeReference.class)))
+                .thenThrow(new JsonProcessingException("bad json") {
+                });
+        ApiResponse response = service.getConsentAcknowledgementDetails("c1", "consent1", "token");
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
     }
 }

--- a/src/test/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImplTest.java
+++ b/src/test/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImplTest.java
@@ -1,0 +1,332 @@
+package com.igot.cb.consentacknowledge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.AccessTokenValidator;
+import com.igot.cb.util.Constants;
+import com.igot.cb.util.ProjectUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.HttpStatus;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ConsentAcknowledgeServiceImplTest {
+
+    @Mock
+    private AccessTokenValidator accessTokenValidator;
+
+    @Mock
+    private CassandraOperation cassandraOperation;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private ConsentAcknowledgeServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_Success() throws Exception {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put(Constants.CONTENT_ID, "content1");
+        requestData.put(Constants.CONSENT_ID, "consent1");
+        requestData.put(Constants.ADDITIONAL_ATTRIBUTES, Map.of("k", "v"));
+        Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"k\":\"v\"}");
+        ApiResponse response = service.acknowledgeDeclaration(body, "token");
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        assertEquals(Constants.OK, response.getParams().getStatus());
+        assertEquals("Declaration acknowledged successfully", response.getResult().get(Constants.RESPONSE));
+        verify(cassandraOperation, times(1)).insertRecord(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_InvalidUser() {
+        Map<String, Object> body = Map.of(Constants.REQUEST, new HashMap<>());
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("");
+        ApiResponse response = service.acknowledgeDeclaration(body, "token");
+        assertNotEquals(Constants.OK, response.getParams().getStatus());
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_MissingContentId() {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put(Constants.CONSENT_ID, "consent1");
+        Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString()))
+                    .thenCallRealMethod();
+            mocked.when(() -> ProjectUtil.errorResponse(any(ApiResponse.class), anyString(), any()))
+                    .thenAnswer(invocation -> {
+                        ApiResponse resp = invocation.getArgument(0);
+                        resp.getParams().setErr(invocation.getArgument(1));
+                        resp.setResponseCode(invocation.getArgument(2));
+                        return null;
+                    });
+            ApiResponse response = service.acknowledgeDeclaration(body, "token");
+            assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+            assertEquals("Missing or invalid contentId.", response.getParams().getErr());
+        }
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_MissingConsentId() {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put(Constants.CONTENT_ID, "content1");
+        Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString()))
+                    .thenCallRealMethod();
+            mocked.when(() -> ProjectUtil.errorResponse(any(ApiResponse.class), anyString(), any()))
+                    .thenAnswer(invocation -> {
+                        ApiResponse resp = invocation.getArgument(0);
+                        resp.getParams().setErr(invocation.getArgument(1));
+                        resp.setResponseCode(invocation.getArgument(2));
+                        return null;
+                    });
+            ApiResponse response = service.acknowledgeDeclaration(body, "token");
+            assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+            assertEquals("Missing or invalid consentId.", response.getParams().getErr());
+        }
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_CassandraInsertFails() throws Exception {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put(Constants.CONTENT_ID, "content1");
+        requestData.put(Constants.CONSENT_ID, "consent1");
+        requestData.put(Constants.ADDITIONAL_ATTRIBUTES, Map.of("k", "v"));
+        Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"k\":\"v\"}");
+        doThrow(new RuntimeException("DB error"))
+                .when(cassandraOperation).insertRecord(any(), any(), any(), any(), any(), any());
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString()))
+                    .thenCallRealMethod();
+            mocked.when(() -> ProjectUtil.errorResponse(any(ApiResponse.class), anyString(), any()))
+                    .thenAnswer(invocation -> {
+                        ApiResponse resp = invocation.getArgument(0);
+                        resp.getParams().setErr(invocation.getArgument(1)); // force set error
+                        resp.setResponseCode(invocation.getArgument(2));
+                        return null;
+                    });
+
+            ApiResponse response = service.acknowledgeDeclaration(body, "token");
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+            assertEquals("Failed to acknowledge declaration. Please try again later.",
+                    response.getParams().getErr());
+        }
+    }
+
+
+    @Test
+    void testGetConsentDetails_Success() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        List<Map<String, Object>> fakeResult = List.of(Map.of(Constants.CONSENT_ID, "consent1", Constants.DESCRIPTION, "desc"));
+        when(cassandraOperation.getRecordsByProperties(any(), any(), any(), any(), any())).thenReturn(fakeResult);
+        ApiResponse response = service.getConsentDetails("consent1", "token");
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        assertTrue(response.getResult().containsKey(Constants.RESPONSE));
+    }
+
+    @Test
+    void testGetConsentDetails_Failure_DBError() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(cassandraOperation.getRecordsByProperties(any(), any(), any(), any(), any()))
+                .thenThrow(new RuntimeException("DB error"));
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString()))
+                    .thenCallRealMethod();
+            mocked.when(() -> ProjectUtil.errorResponse(any(ApiResponse.class), anyString(), any()))
+                    .thenAnswer(invocation -> {
+                        ApiResponse resp = invocation.getArgument(0);
+                        resp.getParams().setErr(invocation.getArgument(1)); // force populate err
+                        resp.setResponseCode(invocation.getArgument(2));
+                        return null;
+                    });
+            ApiResponse response = service.getConsentDetails("consent1", "token");
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+            assertEquals("Failed to fetch consent details. Please try again later.",
+                    response.getParams().getErr());
+        }
+    }
+
+
+    @Test
+    void testGetConsentDetails_InvalidUser() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("");
+        ApiResponse response = service.getConsentDetails("consent1", "token");
+        assertNotEquals(Constants.OK, response.getParams().getStatus());
+    }
+
+
+    @Test
+    void testAcknowledgeDeclaration_EmptyAdditionalData() {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put(Constants.CONTENT_ID, "content1");
+        requestData.put(Constants.CONSENT_ID, "consent1");
+        requestData.put(Constants.ADDITIONAL_ATTRIBUTES, new HashMap<>()); // empty map
+        Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString()))
+                    .thenCallRealMethod();
+            mocked.when(() -> ProjectUtil.errorResponse(any(ApiResponse.class), anyString(), any()))
+                    .thenAnswer(invocation -> {
+                        ApiResponse resp = invocation.getArgument(0);
+                        resp.getParams().setErr(invocation.getArgument(1));
+                        resp.setResponseCode(invocation.getArgument(2));
+                        return null;
+                    });
+            ApiResponse response = service.acknowledgeDeclaration(body, "token");
+            assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+            assertEquals("Missing or invalid additionalData.", response.getParams().getErr());
+        }
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_UserIdEmpty() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("");
+        Map<String, Object> body = Map.of(Constants.REQUEST,
+                Map.of(Constants.CONTENT_ID, "c1", Constants.CONSENT_ID, "x1"));
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString()))
+                    .thenAnswer(inv -> {
+                        ApiResponse resp = new ApiResponse();
+                        resp.getParams().setStatus(Constants.FAILED);
+                        return resp;
+                    });
+            ApiResponse response = service.acknowledgeDeclaration(body, "token");
+            assertEquals(Constants.FAILED, response.getParams().getStatus());
+        }
+    }
+
+
+    @Test
+    void testAcknowledgeDeclaration_RequestDataNull() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        Map<String, Object> body = new HashMap<>();
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString())).thenCallRealMethod();
+            mocked.when(() -> ProjectUtil.errorResponse(any(), anyString(), any()))
+                    .thenAnswer(inv -> {
+                        ApiResponse resp = inv.getArgument(0);
+                        resp.getParams().setErr(inv.getArgument(1));
+                        resp.setResponseCode(inv.getArgument(2));
+                        return null;
+                    });
+
+            ApiResponse response = service.acknowledgeDeclaration(body, "token");
+            assertEquals("Request data is missing.", response.getParams().getErr());
+        }
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_EmptyAdditionalAttributes() {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put(Constants.CONTENT_ID, "c1");
+        requestData.put(Constants.CONSENT_ID, "x1");
+        requestData.put(Constants.ADDITIONAL_ATTRIBUTES, new HashMap<>());
+        Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
+
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString())).thenCallRealMethod();
+            mocked.when(() -> ProjectUtil.errorResponse(any(), anyString(), any()))
+                    .thenAnswer(inv -> {
+                        ApiResponse resp = inv.getArgument(0);
+                        resp.getParams().setErr(inv.getArgument(1));
+                        resp.setResponseCode(inv.getArgument(2));
+                        return null;
+                    });
+
+            ApiResponse response = service.acknowledgeDeclaration(body, "token");
+            assertEquals("Missing or invalid additionalData.", response.getParams().getErr());
+        }
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_JsonProcessingException() throws Exception {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put(Constants.CONTENT_ID, "c1");
+        requestData.put(Constants.CONSENT_ID, "x1");
+        requestData.put(Constants.ADDITIONAL_ATTRIBUTES, Map.of("k", "v"));
+        Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(objectMapper.writeValueAsString(any())).thenThrow(new JsonProcessingException("boom") {
+        });
+        ApiResponse response = service.acknowledgeDeclaration(body, "token");
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        assertNull(((Map<?, ?>) response.getResult()).get(Constants.ADDITIONAL_ATTRIBUTES));
+    }
+
+    @Test
+    void testGetConsentDetails_UserIdEmpty() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("");
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString()))
+                    .thenAnswer(inv -> {
+                        ApiResponse resp = new ApiResponse();
+                        resp.getParams().setStatus(Constants.FAILED);
+                        resp.setResponseCode(HttpStatus.BAD_REQUEST);
+                        return resp;
+                    });
+            ApiResponse response = service.getConsentDetails("c1", "token");
+            assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+            assertEquals(Constants.FAILED, response.getParams().getStatus());
+        }
+    }
+
+
+    @Test
+    void testGetConsentDetails_EmptyListThrows() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(cassandraOperation.getRecordsByProperties(any(), any(), any(), any(), any()))
+                .thenReturn(List.of());
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> service.getConsentDetails("c1", "token"));
+    }
+
+    @Test
+    void testAcknowledgeDeclaration_JsonProcessingFails() throws Exception {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put(Constants.CONTENT_ID, "content1");
+        requestData.put(Constants.CONSENT_ID, "consent1");
+        requestData.put(Constants.ADDITIONAL_ATTRIBUTES, Map.of("k", "v"));
+        Map<String, Object> body = Map.of(Constants.REQUEST, requestData);
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(objectMapper.writeValueAsString(any()))
+                .thenThrow(new JsonProcessingException("boom") {});
+        try (MockedStatic<ProjectUtil> mocked = mockStatic(ProjectUtil.class)) {
+            mocked.when(() -> ProjectUtil.createDefaultResponse(anyString()))
+                    .thenCallRealMethod();
+            mocked.when(() -> ProjectUtil.errorResponse(any(ApiResponse.class), anyString(), any()))
+                    .thenAnswer(invocation -> {
+                        ApiResponse resp = invocation.getArgument(0);
+                        resp.getParams().setErr(invocation.getArgument(1));
+                        resp.setResponseCode(invocation.getArgument(2));
+                        return null;
+                    });
+            ApiResponse response = service.acknowledgeDeclaration(body, "token");
+            assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+            assertEquals("Failed to Parse the additional attributes",
+                    response.getParams().getErr());
+        }
+    }
+}

--- a/src/test/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImplTest.java
+++ b/src/test/java/com/igot/cb/consentacknowledge/ConsentAcknowledgeServiceImplTest.java
@@ -47,6 +47,11 @@ class ConsentAcknowledgeServiceImplTest {
                 .thenReturn("user1");
         when(objectMapper.writeValueAsString(any()))
                 .thenReturn("{\"k\":\"v\"}");
+        ApiResponse insertResponse = new ApiResponse();
+        insertResponse.put(Constants.RESPONSE, Constants.SUCCESS);
+        when(cassandraOperation.insertRecord(
+                any(), any(), any(), any(), any(), any()))
+                .thenReturn(insertResponse);
         ApiResponse response = service.acknowledgeDeclaration(body, "token");
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertEquals(Constants.OK, response.getParams().getStatus());


### PR DESCRIPTION
1. Created two new APIS - consent acknowledgement and consent read.
2. Implemented cassandra insertrecord method based on the primarykey and composite key.
3. Implemented the test cases.