### PR TITLE
KB-12170 | BE|DEV| Create new API for listing the Microcredentials content

### DIFF
--- a/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
+++ b/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
@@ -85,8 +85,8 @@ public class PromotionalContentRuleCacheMgr {
         if (CollectionUtils.isEmpty(cachedRules)) {
             log.info("Cache is empty (size: {}), loading from database", promotionalContentCache.estimatedSize());
             loadAccessSettingRules();
-            cachedRules = promotionalContentCache.asMap().values();
-            log.info("After reload, cache contains {} rules", CollectionUtils.size(cachedRules));
+            cachedRules = new ArrayList<>(promotionalContentCache.asMap().values());
+            log.info("After reload, cache contains {} rules", cachedRules.size());
         }
         return cachedRules;
     }

--- a/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
@@ -240,9 +240,18 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
             Map<String, Object> accessSettingIdMap = (Map<String, Object>) rule.getContextData()
                     .get(Constants.ACCESS_CONTROL_ID);
             if (evaluateAccessSettingRule(accessSettingIdMap, userProfile)) {
-                List<String> fieldsToFetch = Arrays.asList(contentReadFields.split(","));
+                List<String> fieldsToFetch = new ArrayList<>(Arrays.asList(contentReadFields.split(",")));
                 Map<String, Object> contentDetails = contentService.readContent(rule.getContextId(), fieldsToFetch);
-                userCourses.add(contentDetails);
+                // Set default values for missing attributes
+                if (MapUtils.isNotEmpty(contentDetails)) {
+                    Map<String, Object> updateContentDetails = new HashMap<>(contentDetails);
+                    updateContentDetails.putIfAbsent(Constants.AVG_RATING, 0.0);
+                    updateContentDetails.putIfAbsent(Constants.PROGRAM_DURATION, 0);
+                    updateContentDetails.putIfAbsent(Constants.NAME, "");
+                    updateContentDetails.putIfAbsent(Constants.LANGUAGE_MAP_V1, new ArrayList<>());
+                    updateContentDetails.putIfAbsent(Constants.CREATOR_LOGO, "");
+                    userCourses.add(updateContentDetails);
+                }
             }
         }
         return true;

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -477,6 +477,7 @@ public class Constants {
     public static final String API_PROMOTIONAL_CONTENT_METADATA_UPSERT = "api.promotionalcontent.metadata.upsert";
     public static final String API_PROMOTIONAL_ASSIGNEDTO_USERS = "api.promotionalcontent.assignedto.users";
     public static final String USER_GROUPDETAILS_ERR_VALIDATION_MSG = "User group details cannot be null or empty";
+    public static final String PROGRAM_DURATION = "programDuration";
     private Constants() {
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -99,4 +99,4 @@ promotional.content.cache.warming.enabled=true
 promotional.content.cache.batch.size=500
 promotional.content.cache.max.query.size=5000
 promotional.content.cache.ttl.seconds=14400
-promotional.content.read.fields=identifier,courseCategory,contentType,posterImage,mediaType,reviewStatus,status,batches
+promotional.content.read.fields=identifier,courseCategory,contentType,posterImage,mediaType,reviewStatus,status,batches,creatorLogo,languageMapV1,organisation,primaryCategory,name,avgRating,programDuration


### PR DESCRIPTION
1. Caffeine cache was returning empty once cache is expired .
2. Response structure updated for the content read as per the UI requested.