### PR TITLE
KB-12170 | BE|DEV| Create new API for listing the Microcredentials content

### DIFF
--- a/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
+++ b/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
@@ -81,6 +81,7 @@ public class PromotionalContentRuleCacheMgr {
      * @return collection of cached rules, empty collection if none available
      */
     public Collection<CachedAccessSettingRule> getAccessSettingRules() {
+        promotionalContentCache.cleanUp();
         Collection<CachedAccessSettingRule> cachedRules = promotionalContentCache.asMap().values();
         if (CollectionUtils.isEmpty(cachedRules)) {
             log.info("Cache is empty (size: {}), loading from database", promotionalContentCache.estimatedSize());
@@ -157,10 +158,10 @@ public class PromotionalContentRuleCacheMgr {
                         promotionalContentCache.put(rule.getCacheKey(), rule);
                     });
             long totalProcessed = promotionalContentCache.estimatedSize();
-            log.info("Access setting rules loaded into cache successfully. Total rules loaded: {}",
+            log.info("Promotional Content rules loaded into cache successfully. Total rules loaded: {}",
                     totalProcessed);
         } catch (Exception e) {
-            log.error("Failed to load AccessSettingRule into Cache. Exception: ", e);
+            log.error("Failed to load Promotional Content rules into Cache. Exception: ", e);
         }
     }
 


### PR DESCRIPTION
1.Added promotionalContentCache.cleanUp() call in getAccessSettingRules()  to immediately evict expired entries instead of relying on lazy eviction. 2.This ensures the cache properly detects when entries have expired and triggers database reload, preventing stale data from being returned when  TTL expires.