### PR TITLE
KB-11897 | The Deleted Promotional Content Metadata being shown even …

### DIFF
--- a/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
+++ b/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
@@ -147,6 +147,10 @@ public class PromotionalContentRuleCacheMgr {
             }
             log.info("Total records fetched: {}, processing with parallel streams...", allRecords.size());
             allRecords.parallelStream()
+                    .filter(rec -> {
+                        Boolean isArchived = (Boolean) rec.get(Constants.IS_ARCHIVED_KEY);
+                        return !isArchived;
+                    })
                     .map(rec -> new CachedAccessSettingRule(
                             (String) rec.get("contextId"),
                             (String) rec.get("contextIdType"),

--- a/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
@@ -312,7 +312,7 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
     public ApiResponse delete(String contentId) {
         log.info("PromotionalContentServiceImpl::delete:inside");
         ApiResponse response = ApiResponse.createDefaultResponse("api.promotionalcontent.metadata.delete");
-        if (org.apache.commons.lang.StringUtils.isBlank(contentId)) {
+        if (StringUtils.isEmpty(contentId)) {
             log.error("Content ID is null or empty");
             setFailedResponse(response, "Content ID cannot be null or empty");
             return response;
@@ -321,7 +321,9 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
             Map<String, Object> accessRuleData = new HashMap<>();
             accessRuleData.put(Constants.CONTEXT_ID, contentId);
             accessRuleData.put(Constants.CONTEXT_DATA, "");
-            accessRuleData.put(Constants.IS_ARCHIVED, false);
+            accessRuleData.put(Constants.IS_ARCHIVED, true);
+            String contextIdType = contentService.readCourseCategoryForContent(contentId);
+            accessRuleData.put(Constants.CONTEXT_ID_TYPE, contextIdType);
             cassandraOperation.insertRecord(Constants.KEYSPACE_SUNBIRD_COURSE,
                     Constants.PROMOTIONAL_CONTENT_RULES, accessRuleData);
             response.setResponseCode(HttpStatus.OK);

--- a/src/test/java/com/igot/cb/cache/AccessSettingRuleCacheMgrTest.java
+++ b/src/test/java/com/igot/cb/cache/AccessSettingRuleCacheMgrTest.java
@@ -5,9 +5,8 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 import java.lang.reflect.Field;
-import java.util.concurrent.ConcurrentHashMap;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.igot.cb.cassandra.CassandraOperation;
 import com.igot.cb.model.CachedAccessSettingRule;
 
@@ -37,7 +36,21 @@ class AccessSettingRuleCacheMgrTest {
 
     @BeforeEach
     void setup() throws Exception {
-        cacheMgr = new AccessSettingRuleCacheMgr(redisCacheMgr, cassandraOperation); // 10 minutes TTL
+        cacheMgr = new AccessSettingRuleCacheMgr(redisCacheMgr, cassandraOperation);
+        try {
+            Field ttlField = AccessSettingRuleCacheMgr.class.getDeclaredField("ttlMinutes");
+            ttlField.setAccessible(true);
+            ttlField.setInt(cacheMgr, 10);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set ttlMinutes in test", e);
+        }
+        try {
+            var method = AccessSettingRuleCacheMgr.class.getDeclaredMethod("initCache");
+            method.setAccessible(true);
+            method.invoke(cacheMgr);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to initialize cache in test", e);
+        }
 
         validJsonRule = """
         {
@@ -273,15 +286,15 @@ class AccessSettingRuleCacheMgrTest {
 
     @Test
     void testGetOrLoadAccessSettingRule_cacheHit() {
-        // Use reflection to insert an entry into the internal cache
+        // Use reflection to insert an entry into the Caffeine cache
         CachedAccessSettingRule rule = new CachedAccessSettingRule("do_123", "Course", "{}", false);
 
         try {
-            Field field = AccessSettingRuleCacheMgr.class.getDeclaredField("cachedAccessSettingRules");
+            Field field = AccessSettingRuleCacheMgr.class.getDeclaredField("accessSettingsCache");
             field.setAccessible(true);
-            Map<String, CachedAccessSettingRule> internalCache = new ConcurrentHashMap<>();
-            internalCache.put("do_123|Course", rule);
-            field.set(cacheMgr, internalCache);
+            Cache<String, CachedAccessSettingRule> cache =
+                (Cache<String, CachedAccessSettingRule>) field.get(cacheMgr);
+            cache.put("do_123|Course", rule);
         } catch (Exception e) {
             fail("Reflection failed: " + e.getMessage());
         }

--- a/src/test/java/com/igot/cb/cache/PromotionalContentRuleCacheMgrTest.java
+++ b/src/test/java/com/igot/cb/cache/PromotionalContentRuleCacheMgrTest.java
@@ -121,10 +121,10 @@ class PromotionalContentRuleCacheMgrTest {
     @Test
     void testProcessCriteria_WithNonIntegerValues() {
         String contextData = "{\"accessControlId\":{\"version\":1,\"userGroups\":[{\"userGroupId\":\"group-1\",\"userGroupName\":\"Group 1\",\"userGroupCriteriaList\":[{\"criteriaKey\":\"designation\",\"criteriaValue\":[\"1\",\"invalid\",\"3\",\"not-a-number\",\"5\"]}]}]}}";
-        Map<String, Object> record = createCassandraRecord("do_non_integer", "Course", contextData);
+        Map<String, Object> nonIntegerRecord = createCassandraRecord("do_non_integer", "Course", contextData);
         when(cassandraOperation.getRecordsByProperties(
                 anyString(), anyString(), any(), any(), anyInt()
-        )).thenReturn(List.of(record));
+        )).thenReturn(List.of(nonIntegerRecord));
         Collection<CachedAccessSettingRule> result = cacheMgr.getAccessSettingRules();
         assertEquals(1, result.size());
         CachedAccessSettingRule rule = result.iterator().next();
@@ -143,10 +143,10 @@ class PromotionalContentRuleCacheMgrTest {
 
     @Test
     void testProcessContextData_WithNoAccessControl() {
-        Map<String, Object> record = createCassandraRecord("do_no_access", "Course", "{}");
+        Map<String, Object> noAccessControlRecord = createCassandraRecord("do_no_access", "Course", "{}");
         when(cassandraOperation.getRecordsByProperties(
                 anyString(), anyString(), any(), any(), anyInt()
-        )).thenReturn(List.of(record));
+        )).thenReturn(List.of(noAccessControlRecord));
         Collection<CachedAccessSettingRule> result = cacheMgr.getAccessSettingRules();
         assertEquals(1, result.size());
     }
@@ -190,11 +190,12 @@ class PromotionalContentRuleCacheMgrTest {
     }
 
     private Map<String, Object> createCassandraRecord(String contextId, String contextIdType, String contextData) {
-        Map<String, Object> record = new HashMap<>();
-        record.put("contextId", contextId);
-        record.put("contextIdType", contextIdType);
-        record.put("contextData", contextData);
-        return record;
+        Map<String, Object> createCassandraRecord = new HashMap<>();
+        createCassandraRecord.put("contextId", contextId);
+        createCassandraRecord.put("contextIdType", contextIdType);
+        createCassandraRecord.put("contextData", contextData);
+        createCassandraRecord.put("isArchived", false);
+        return createCassandraRecord;
     }
 
     private Map<String, Object> createCassandraRecordWithFullData(String contextId, String contextIdType) {


### PR DESCRIPTION
…after the Cache clear (#165)

* KB-11897 | The Deleted Promotional Content Metadata being shown even after the Cache clear

1.  contextIdType is a part of the composite key due to which the soft delete was failing added it also setting the isArchived=true.
2. While fetching only fetching the isArchived with false data .
3. Updated the test cases accordingly.
4. There were few test cases failing in accesssettingrulecacheamgr - fixed it.

* Fixed the sonar issues highlighed