### PR TITLE
KB-11897 | The Deleted Promotional Content Metadata being shown even after the Cache clear

### DIFF
--- a/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
+++ b/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
@@ -87,6 +87,7 @@ public class PromotionalContentRuleCacheMgr {
 
         log.info("Loading access setting rules from database - Batch size: {}, Max query size: {}",
                 batchSize, maxQuerySize);
+        cacheMap.clear();
         try {
             List<Map<String, Object>> allRecords = new ArrayList<>();
             int totalFetched = 0;


### PR DESCRIPTION
1. clearing the map when the cache is expired and reloading the data again.