### PR TITLE
KB-12345 | BE|DEV| Create new API for reading the Microcredentials content created

### DIFF
--- a/src/main/java/com/igot/cb/controller/PromotionalContentController.java
+++ b/src/main/java/com/igot/cb/controller/PromotionalContentController.java
@@ -32,8 +32,9 @@ public class PromotionalContentController {
     }
 
     @DeleteMapping("/v1/delete/{contentId}")
-    public ResponseEntity<ApiResponse> delete(@PathVariable("contentId") String contentId) {
-        ApiResponse response = promotionalContentService.delete(contentId);
+    public ResponseEntity<ApiResponse> delete(@PathVariable("contentId") String contentId,
+                                              @RequestHeader(Constants.X_AUTH_TOKEN) String authToken) {
+        ApiResponse response = promotionalContentService.delete(contentId, authToken);
         return new ResponseEntity<>(response, response.getResponseCode());
     }
 }

--- a/src/main/java/com/igot/cb/controller/PromotionalContentController.java
+++ b/src/main/java/com/igot/cb/controller/PromotionalContentController.java
@@ -37,4 +37,12 @@ public class PromotionalContentController {
         ApiResponse response = promotionalContentService.delete(contentId, authToken);
         return new ResponseEntity<>(response, response.getResponseCode());
     }
+
+    @GetMapping("/v1/read/{contentId}")
+    public ResponseEntity<ApiResponse> read(@PathVariable("contentId") String contentId,
+                                            @RequestHeader(Constants.X_AUTH_TOKEN) String authToken) {
+        ApiResponse response = promotionalContentService.read(contentId, authToken);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
 }

--- a/src/main/java/com/igot/cb/service/IPromotionalContentService.java
+++ b/src/main/java/com/igot/cb/service/IPromotionalContentService.java
@@ -10,4 +10,6 @@ public interface IPromotionalContentService {
     ApiResponse getPromotionalContentForUsers(String authToken);
 
     ApiResponse delete(String contentId, String authToken);
+
+    ApiResponse read(String contentId, String authToken);
 }

--- a/src/main/java/com/igot/cb/service/IPromotionalContentService.java
+++ b/src/main/java/com/igot/cb/service/IPromotionalContentService.java
@@ -9,5 +9,5 @@ public interface IPromotionalContentService {
 
     ApiResponse getPromotionalContentForUsers(String authToken);
 
-    ApiResponse delete(String contentId);
+    ApiResponse delete(String contentId, String authToken);
 }

--- a/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.cache.PromotionalContentRuleCacheMgr;
 import com.igot.cb.cache.RedisCacheMgr;
 import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.cassandra.exceptions.CustomException;
 import com.igot.cb.model.ApiResponse;
 import com.igot.cb.model.CachedAccessSettingRule;
 import com.igot.cb.util.AccessTokenValidator;
@@ -29,6 +30,8 @@ import static com.igot.cb.util.ProjectUtil.setFailedResponse;
 @Service
 @Slf4j
 public class PromotionalContentServiceImpl implements IPromotionalContentService {
+    private static final String NO_ACCESS_SETTINGS_FOUND = "No access settings found for the given contentId";
+    
     private final AccessTokenValidator accessTokenValidator;
     private final PayloadValidation payloadValidation;
     private final ObjectMapper objectMapper;
@@ -338,6 +341,94 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
             log.error("Error while deleting accessRule:", e);
             setFailedResponse(response, "Failed to delete access settings: " + e);
             return response;
+        }
+    }
+
+    @Override
+    public ApiResponse read(String contentId, String authToken) {
+        log.info("PromotionalContentServiceImpl::read:inside - contentId: {}", contentId);
+        ApiResponse response = ApiResponse.createDefaultResponse(Constants.API_ACCESS_RULE_READ);
+        try {
+            String contextIdType = contentService.readCourseCategoryForContent(contentId);
+            log.debug("Retrieved context ID type: {} for contentId: {}", contextIdType, contentId);
+            Map<String, Object> propertyMap = new HashMap<>();
+            propertyMap.put(Constants.CONTEXT_ID, contentId);
+            propertyMap.put(Constants.CONTEXT_ID_TYPE, contextIdType);
+            List<String> fields = Arrays.asList(Constants.CONTEXT_ID, Constants.CONTEXT_DATA, Constants.IS_ARCHIVED);
+            log.debug("Fetching promotional content setting rules from Cassandra for contentId: {}", contentId);
+            List<Map<String, Object>> accessSettingRule = cassandraOperation.getRecordsByProperties(
+                    Constants.KEYSPACE_SUNBIRD_COURSE, Constants.PROMOTIONAL_CONTENT_RULES, propertyMap,
+                    fields, null);
+            if (accessSettingRule.isEmpty()) {
+                log.warn("No promotional content rules found for contentId: {}", contentId);
+                setFailedResponse(response, NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+                return response;
+            }
+            log.debug("Found {} promotional content setting rule(s) for contentId: {}", accessSettingRule.size(), contentId);
+            return processContentSettingRecord(accessSettingRule.get(0), response);
+        } catch (Exception e) {
+            log.error("Error while reading promotional content rule for contentId: {}", contentId, e);
+            throw new CustomException(
+                    Constants.ERROR,
+                    "error while processing",
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Processing promotional content setting record.
+     *
+     * @param accessRecord the access setting record
+     * @param response     the API response
+     * @return populated ApiResponse
+     */
+    private ApiResponse processContentSettingRecord(Map<String, Object> accessRecord, ApiResponse response) {
+        log.debug("Processing promotional content setting record");
+        Boolean status = (Boolean) accessRecord.get(Constants.IS_ARCHIVED_KEY);
+        log.debug("Promotional content setting archived status: {}", status);
+        if (Boolean.TRUE.equals(status)) {
+            log.warn("Promotional Content Access setting is archived, cannot retrieve");
+            setFailedResponse(response, NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+            return response;
+        }
+        Object contextDataObj = accessRecord.get(Constants.CONTEXT_DATA_KEY);
+        if (!(contextDataObj instanceof String contextDataJson) ||
+                StringUtils.isEmpty(contextDataJson)) {
+            log.warn("Context data is empty or not a valid string");
+            setFailedResponse(response, NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+            return response;
+        }
+        log.debug("Context data found, proceeding to parse JSON");
+        return parseAndSetContextData(contextDataJson, response);
+    }
+
+    /**
+     * Parse context data JSON and set it in the response.
+     *
+     * @param contextDataJson JSON string containing context data
+     * @param response        the API response
+     * @return populated ApiResponse
+     */
+    private ApiResponse parseAndSetContextData(String contextDataJson, ApiResponse response) {
+        try {
+            log.debug("Parsing context data JSON, length: {}", contextDataJson.length());
+            Map<String, Object> contextDataMap = objectMapper.readValue(
+                    contextDataJson, new TypeReference<Map<String, Object>>() {
+                    });
+            log.debug("Successfully parsed context data, entries: {}", contextDataMap.size());
+            if (!contextDataMap.isEmpty()) {
+                contextDataMap.remove(Constants.ACCESS_CONTROL_ID);
+                log.debug("Removed ACCESS_CONTROL_ID from context data");
+            }
+            response.setResult(contextDataMap);
+            log.info("Successfully retrieved and set access settings in response");
+            return response;
+        } catch (Exception e) {
+            log.error("Failed to parse CONTEXT_DATA JSON: {}", contextDataJson, e);
+            throw new CustomException(
+                    Constants.ERROR,
+                    "error while processing",
+                    HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
@@ -360,7 +360,7 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
                     fields, null);
             if (accessSettingRule.isEmpty()) {
                 log.warn("No promotional content rules found for contentId: {}", contentId);
-                setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+                setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.OK);
                 return response;
             }
             log.debug("Found {} promotional content setting rule(s) for contentId: {}", accessSettingRule.size(), contentId);
@@ -389,14 +389,14 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
         log.debug("Promotional content setting archived status: {}", status);
         if (Boolean.TRUE.equals(status)) {
             log.warn("Promotional Content Access setting is archived, cannot retrieve");
-            setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+            setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.OK);
             return Collections.emptyMap();
         }
         Object contextDataObj = accessRecord.get(Constants.CONTEXT_DATA_KEY);
         if (!(contextDataObj instanceof String contextDataJson) ||
                 StringUtils.isEmpty(contextDataJson)) {
             log.warn("Context data is empty or not a valid string");
-            setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+            setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.OK);
             return Collections.emptyMap();
         }
         log.debug("Context data found, proceeding to parse JSON");

--- a/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.cache.PromotionalContentRuleCacheMgr;
 import com.igot.cb.cache.RedisCacheMgr;
 import com.igot.cb.cassandra.CassandraOperation;
-import com.igot.cb.cassandra.exceptions.CustomException;
 import com.igot.cb.model.ApiResponse;
 import com.igot.cb.model.CachedAccessSettingRule;
 import com.igot.cb.util.AccessTokenValidator;
@@ -15,6 +14,7 @@ import com.igot.cb.util.PayloadValidation;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.keycloak.common.util.CollectionUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -30,8 +30,7 @@ import static com.igot.cb.util.ProjectUtil.setFailedResponse;
 @Service
 @Slf4j
 public class PromotionalContentServiceImpl implements IPromotionalContentService {
-    private static final String NO_ACCESS_SETTINGS_FOUND = "No access settings found for the given contentId";
-    
+
     private final AccessTokenValidator accessTokenValidator;
     private final PayloadValidation payloadValidation;
     private final ObjectMapper objectMapper;
@@ -361,17 +360,19 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
                     fields, null);
             if (accessSettingRule.isEmpty()) {
                 log.warn("No promotional content rules found for contentId: {}", contentId);
-                setFailedResponse(response, NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+                setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
                 return response;
             }
             log.debug("Found {} promotional content setting rule(s) for contentId: {}", accessSettingRule.size(), contentId);
-            return processContentSettingRecord(accessSettingRule.get(0), response);
+            Map<String, Object> contextDataMap = processContentSettingRecord(accessSettingRule.get(0), response);
+            if (MapUtils.isNotEmpty(contextDataMap)) {
+                response.setResult(contextDataMap);
+            }
+            return response;
         } catch (Exception e) {
             log.error("Error while reading promotional content rule for contentId: {}", contentId, e);
-            throw new CustomException(
-                    Constants.ERROR,
-                    "error while processing",
-                    HttpStatus.INTERNAL_SERVER_ERROR);
+            setFailedResponse(response, "error while processing", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response;
         }
     }
 
@@ -380,36 +381,36 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
      *
      * @param accessRecord the access setting record
      * @param response     the API response
-     * @return populated ApiResponse
+     * @return parsed context data map, or null if error occurred
      */
-    private ApiResponse processContentSettingRecord(Map<String, Object> accessRecord, ApiResponse response) {
+    private Map<String, Object> processContentSettingRecord(Map<String, Object> accessRecord, ApiResponse response) {
         log.debug("Processing promotional content setting record");
         Boolean status = (Boolean) accessRecord.get(Constants.IS_ARCHIVED_KEY);
         log.debug("Promotional content setting archived status: {}", status);
         if (Boolean.TRUE.equals(status)) {
             log.warn("Promotional Content Access setting is archived, cannot retrieve");
-            setFailedResponse(response, NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
-            return response;
+            setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+            return Collections.emptyMap();
         }
         Object contextDataObj = accessRecord.get(Constants.CONTEXT_DATA_KEY);
         if (!(contextDataObj instanceof String contextDataJson) ||
                 StringUtils.isEmpty(contextDataJson)) {
             log.warn("Context data is empty or not a valid string");
-            setFailedResponse(response, NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
-            return response;
+            setFailedResponse(response, Constants.NO_ACCESS_SETTINGS_FOUND, HttpStatus.NOT_FOUND);
+            return Collections.emptyMap();
         }
         log.debug("Context data found, proceeding to parse JSON");
         return parseAndSetContextData(contextDataJson, response);
     }
 
     /**
-     * Parse context data JSON and set it in the response.
+     * Parse context data JSON and return the parsed map.
      *
      * @param contextDataJson JSON string containing context data
      * @param response        the API response
-     * @return populated ApiResponse
+     * @return parsed context data map, or null if error occurred
      */
-    private ApiResponse parseAndSetContextData(String contextDataJson, ApiResponse response) {
+    private Map<String, Object> parseAndSetContextData(String contextDataJson, ApiResponse response) {
         try {
             log.debug("Parsing context data JSON, length: {}", contextDataJson.length());
             Map<String, Object> contextDataMap = objectMapper.readValue(
@@ -420,15 +421,12 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
                 contextDataMap.remove(Constants.ACCESS_CONTROL_ID);
                 log.debug("Removed ACCESS_CONTROL_ID from context data");
             }
-            response.setResult(contextDataMap);
             log.info("Successfully retrieved and set access settings in response");
-            return response;
+            return contextDataMap;
         } catch (Exception e) {
             log.error("Failed to parse CONTEXT_DATA JSON: {}", contextDataJson, e);
-            throw new CustomException(
-                    Constants.ERROR,
-                    "error while processing",
-                    HttpStatus.INTERNAL_SERVER_ERROR);
+            setFailedResponse(response, "error while processing", HttpStatus.INTERNAL_SERVER_ERROR);
+            return Collections.emptyMap();
         }
     }
 }

--- a/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
@@ -307,11 +307,16 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
      * Deletes promotional content metadata by marking it as archived.
      *
      * @param contentId ID of the promotional content to delete
+     * @param authToken authentication token for user validation
      * @return ApiResponse with operation result
      */
-    public ApiResponse delete(String contentId) {
+    public ApiResponse delete(String contentId, String authToken) {
         log.info("PromotionalContentServiceImpl::delete:inside");
         ApiResponse response = ApiResponse.createDefaultResponse("api.promotionalcontent.metadata.delete");
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authToken, response);
+        if (StringUtils.isEmpty(userId)) {
+            return response;
+        }
         if (StringUtils.isEmpty(contentId)) {
             log.error("Content ID is null or empty");
             setFailedResponse(response, "Content ID cannot be null or empty");

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -478,6 +478,7 @@ public class Constants {
     public static final String API_PROMOTIONAL_ASSIGNEDTO_USERS = "api.promotionalcontent.assignedto.users";
     public static final String USER_GROUPDETAILS_ERR_VALIDATION_MSG = "User group details cannot be null or empty";
     public static final String PROGRAM_DURATION = "programDuration";
+    public static final String NO_ACCESS_SETTINGS_FOUND = "No access settings found for the given contentId";
     private Constants() {
     }
 }

--- a/src/test/java/com/igot/cb/service/PromotionalContentServiceImplTest.java
+++ b/src/test/java/com/igot/cb/service/PromotionalContentServiceImplTest.java
@@ -13,6 +13,9 @@ import com.igot.cb.util.PayloadValidation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -184,7 +188,7 @@ class PromotionalContentServiceImplTest {
         assertNotNull(result);
         assertEquals(HttpStatus.OK, result.getResponseCode());
         assertNotNull(result.getResult().get(Constants.CONTENT));
-        verify(redisCacheMgr).getFromCache(eq(Constants.PROMOTIONAL_CONTENT_KEY + USER_ID), eq(600));
+        verify(redisCacheMgr).getFromCache(Constants.PROMOTIONAL_CONTENT_KEY + USER_ID, 600);
     }
 
     @Test
@@ -438,7 +442,7 @@ class PromotionalContentServiceImplTest {
         assertNotNull(result);
         List<Map<String, Object>> content = (List<Map<String, Object>>) result.getResult().get(Constants.CONTENT);
         assertTrue(content.isEmpty());
-        verify(redisCacheMgr).putInCache(eq(Constants.ACCESS_KEY + USER_ID), eq(Constants.NO_RECORDS_FOUND), eq(600));
+        verify(redisCacheMgr).putInCache(Constants.ACCESS_KEY + USER_ID, Constants.NO_RECORDS_FOUND, 600);
     }
 
     @Test
@@ -722,5 +726,192 @@ class PromotionalContentServiceImplTest {
         when(rule.getContextId()).thenReturn("content-123");
         rules.add(rule);
         return rules;
+    }
+
+
+    @Test
+    void testRead_Success() throws Exception {
+        String contextIdType = "Course";
+        Map<String, Object> accessRecord = new HashMap<>();
+        accessRecord.put(Constants.IS_ARCHIVED_KEY, false);
+        String contextDataJson = "{\"accessControl\":{\"userGroups\":[]},\"accessControlId\":{}}";
+        accessRecord.put(Constants.CONTEXT_DATA_KEY, contextDataJson);
+        Map<String, Object> expectedContextData = new HashMap<>();
+        expectedContextData.put("accessControl", Map.of("userGroups", Collections.emptyList()));
+        expectedContextData.put("accessControlId", Collections.emptyMap());
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn(contextIdType);
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSE),
+                eq(Constants.PROMOTIONAL_CONTENT_RULES),
+                any(Map.class),
+                anyList(),
+                isNull()
+        )).thenReturn(List.of(accessRecord));
+        when(objectMapper.readValue(eq(contextDataJson), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenReturn(expectedContextData);
+        ApiResponse result = promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        assertNotNull(result);
+        assertEquals(expectedContextData, result.getResult());
+        verify(contentService).readCourseCategoryForContent(CONTENT_ID);
+        verify(cassandraOperation).getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSE),
+                eq(Constants.PROMOTIONAL_CONTENT_RULES),
+                any(Map.class),
+                anyList(),
+                isNull()
+        );
+        verify(objectMapper).readValue(eq(contextDataJson), any(com.fasterxml.jackson.core.type.TypeReference.class));
+    }
+
+    @Test
+    void testRead_NoAccessSettingsFound() throws Exception {
+        String contextIdType = "Course";
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn(contextIdType);
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSE),
+                eq(Constants.PROMOTIONAL_CONTENT_RULES),
+                any(Map.class),
+                anyList(),
+                isNull()
+        )).thenReturn(Collections.emptyList());
+        ApiResponse result = promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        assertNotNull(result);
+        assertEquals(HttpStatus.NOT_FOUND, result.getResponseCode());
+        assertEquals(Constants.FAILED, result.getParams().getStatus());
+        assertEquals("No access settings found for the given contentId", result.getParams().getErrMsg());
+        verify(contentService).readCourseCategoryForContent(CONTENT_ID);
+        verify(objectMapper, never()).readValue(anyString(), any(com.fasterxml.jackson.core.type.TypeReference.class));
+    }
+
+    private static Stream<Arguments> provideInvalidContextDataScenarios() {
+        return Stream.of(
+                Arguments.of("Archived record", true, "{\"accessControl\":{}}", "Archived record scenario"),
+                Arguments.of("Empty context data", false, "", "Empty string scenario"),
+                Arguments.of("Null context data", false, null, "Null value scenario"),
+                Arguments.of("Non-string context data", false, 12345, "Non-string type scenario")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideInvalidContextDataScenarios")
+    void testRead_InvalidContextData(String testName, boolean isArchived, Object contextData, String description) throws Exception {
+        String contextIdType = "Course";
+        Map<String, Object> accessRecord = new HashMap<>();
+        accessRecord.put(Constants.IS_ARCHIVED_KEY, isArchived);
+        accessRecord.put(Constants.CONTEXT_DATA_KEY, contextData);
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn(contextIdType);
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSE),
+                eq(Constants.PROMOTIONAL_CONTENT_RULES),
+                any(Map.class),
+                anyList(),
+                isNull()
+        )).thenReturn(List.of(accessRecord));
+        ApiResponse result = promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        assertNotNull(result);
+        assertEquals(HttpStatus.NOT_FOUND, result.getResponseCode());
+        assertEquals(Constants.FAILED, result.getParams().getStatus());
+        assertEquals("No access settings found for the given contentId", result.getParams().getErrMsg());
+        verify(objectMapper, never()).readValue(anyString(), any(com.fasterxml.jackson.core.type.TypeReference.class));
+    }
+
+    @Test
+    void testRead_JsonParsingException() throws Exception {
+        String contextIdType = "Course";
+        Map<String, Object> accessRecord = new HashMap<>();
+        accessRecord.put(Constants.IS_ARCHIVED_KEY, false);
+        String invalidJson = "{invalid json}";
+        accessRecord.put(Constants.CONTEXT_DATA_KEY, invalidJson);
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn(contextIdType);
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSE),
+                eq(Constants.PROMOTIONAL_CONTENT_RULES),
+                any(Map.class),
+                anyList(),
+                isNull()
+        )).thenReturn(List.of(accessRecord));
+        when(objectMapper.readValue(eq(invalidJson), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenThrow(new JsonProcessingException("Invalid JSON") {});
+        assertThrows(com.igot.cb.cassandra.exceptions.CustomException.class, () -> {
+            promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        });
+        verify(objectMapper).readValue(eq(invalidJson), any(com.fasterxml.jackson.core.type.TypeReference.class));
+    }
+
+    @Test
+    void testRead_RemovesAccessControlId() throws Exception {
+        String contextIdType = "Course";
+        Map<String, Object> accessRecord = new HashMap<>();
+        accessRecord.put(Constants.IS_ARCHIVED_KEY, false);
+        String contextDataJson = "{\"accessControl\":{},\"accessControlId\":{\"id\":\"123\"}}";
+        accessRecord.put(Constants.CONTEXT_DATA_KEY, contextDataJson);
+        Map<String, Object> parsedData = new HashMap<>();
+        parsedData.put("accessControl", Collections.emptyMap());
+        parsedData.put("accessControlId", Map.of("id", "123"));
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn(contextIdType);
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSE),
+                eq(Constants.PROMOTIONAL_CONTENT_RULES),
+                any(Map.class),
+                anyList(),
+                isNull()
+        )).thenReturn(List.of(accessRecord));
+        when(objectMapper.readValue(eq(contextDataJson), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenReturn(parsedData);
+        ApiResponse result = promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        assertNotNull(result);
+        assertFalse(result.getResult().containsKey("accessControlId"));
+        assertTrue(result.getResult().containsKey("accessControl"));
+    }
+
+    @Test
+    void testRead_EmptyContextDataMap() throws Exception {
+        String contextIdType = "Course";
+        Map<String, Object> accessRecord = new HashMap<>();
+        accessRecord.put(Constants.IS_ARCHIVED_KEY, false);
+        String contextDataJson = "{}";
+        accessRecord.put(Constants.CONTEXT_DATA_KEY, contextDataJson);
+        Map<String, Object> emptyMap = new HashMap<>();
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn(contextIdType);
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSE),
+                eq(Constants.PROMOTIONAL_CONTENT_RULES),
+                any(Map.class),
+                anyList(),
+                isNull()
+        )).thenReturn(List.of(accessRecord));
+        when(objectMapper.readValue(eq(contextDataJson), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenReturn(emptyMap);
+        ApiResponse result = promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        assertNotNull(result);
+        assertTrue(result.getResult().isEmpty());
+    }
+
+    @Test
+    void testRead_DatabaseException() throws Exception {
+        String contextIdType = "Course";
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn(contextIdType);
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSE),
+                eq(Constants.PROMOTIONAL_CONTENT_RULES),
+                any(Map.class),
+                anyList(),
+                isNull()
+        )).thenThrow(new RuntimeException("Database connection failed"));
+        assertThrows(com.igot.cb.cassandra.exceptions.CustomException.class, () -> {
+            promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        });
+        verify(objectMapper, never()).readValue(anyString(), any(com.fasterxml.jackson.core.type.TypeReference.class));
+    }
+
+    @Test
+    void testRead_ContentServiceException() {
+        when(contentService.readCourseCategoryForContent(CONTENT_ID))
+                .thenThrow(new RuntimeException("Content service unavailable"));
+        assertThrows(com.igot.cb.cassandra.exceptions.CustomException.class, () -> {
+            promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        });
+        verify(cassandraOperation, never()).getRecordsByProperties(
+                anyString(), anyString(), any(), anyList(), any());
     }
 }

--- a/src/test/java/com/igot/cb/service/PromotionalContentServiceImplTest.java
+++ b/src/test/java/com/igot/cb/service/PromotionalContentServiceImplTest.java
@@ -283,19 +283,28 @@ class PromotionalContentServiceImplTest {
     @Test
     void testDelete_Success() {
         ApiResponse mockResponse = ApiResponse.createDefaultResponse("test");
+        when(accessTokenValidator.fetchUserIdFromAccessToken(eq(AUTH_TOKEN), any(ApiResponse.class)))
+                .thenReturn(USER_ID);
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn("Course");
         when(cassandraOperation.insertRecord(anyString(), anyString(), any())).thenReturn(mockResponse);
-        ApiResponse result = promotionalContentService.delete(CONTENT_ID);
+        
+        ApiResponse result = promotionalContentService.delete(CONTENT_ID, AUTH_TOKEN);
+        
         assertNotNull(result);
         assertEquals(HttpStatus.OK, result.getResponseCode());
-        assertTrue(result.getResult().get(Constants.MSG).toString()
-                .contains("Promotional Content Metadata deleted successfully"));
+        assertEquals("Promotional Content Metadata deleted successfully", 
+                result.getResult().get(Constants.MSG));
         verify(cassandraOperation).insertRecord(eq(Constants.KEYSPACE_SUNBIRD_COURSE),
                 eq(Constants.PROMOTIONAL_CONTENT_RULES), any());
     }
 
     @Test
     void testDelete_EmptyContentId() {
-        ApiResponse result = promotionalContentService.delete("");
+        when(accessTokenValidator.fetchUserIdFromAccessToken(eq(AUTH_TOKEN), any(ApiResponse.class)))
+                .thenReturn(USER_ID);
+        
+        ApiResponse result = promotionalContentService.delete("", AUTH_TOKEN);
+        
         assertNotNull(result);
         assertEquals(HttpStatus.BAD_REQUEST, result.getResponseCode());
         assertEquals(Constants.FAILED, result.getParams().getStatus());
@@ -304,7 +313,11 @@ class PromotionalContentServiceImplTest {
 
     @Test
     void testDelete_NullContentId() {
-        ApiResponse result = promotionalContentService.delete(null);
+        when(accessTokenValidator.fetchUserIdFromAccessToken(eq(AUTH_TOKEN), any(ApiResponse.class)))
+                .thenReturn(USER_ID);
+        
+        ApiResponse result = promotionalContentService.delete(null, AUTH_TOKEN);
+        
         assertNotNull(result);
         assertEquals(HttpStatus.BAD_REQUEST, result.getResponseCode());
         assertEquals(Constants.FAILED, result.getParams().getStatus());
@@ -312,9 +325,14 @@ class PromotionalContentServiceImplTest {
 
     @Test
     void testDelete_ExceptionDuringDeletion() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(eq(AUTH_TOKEN), any(ApiResponse.class)))
+                .thenReturn(USER_ID);
+        when(contentService.readCourseCategoryForContent(CONTENT_ID)).thenReturn("Course");
         when(cassandraOperation.insertRecord(anyString(), anyString(), any()))
                 .thenThrow(new RuntimeException("Database error"));
-        ApiResponse result = promotionalContentService.delete(CONTENT_ID);
+        
+        ApiResponse result = promotionalContentService.delete(CONTENT_ID, AUTH_TOKEN);
+        
         assertNotNull(result);
         assertEquals(HttpStatus.BAD_REQUEST, result.getResponseCode());
         assertEquals(Constants.FAILED, result.getParams().getStatus());

--- a/src/test/java/com/igot/cb/service/PromotionalContentServiceImplTest.java
+++ b/src/test/java/com/igot/cb/service/PromotionalContentServiceImplTest.java
@@ -832,9 +832,11 @@ class PromotionalContentServiceImplTest {
         )).thenReturn(List.of(accessRecord));
         when(objectMapper.readValue(eq(invalidJson), any(com.fasterxml.jackson.core.type.TypeReference.class)))
                 .thenThrow(new JsonProcessingException("Invalid JSON") {});
-        assertThrows(com.igot.cb.cassandra.exceptions.CustomException.class, () -> {
-            promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
-        });
+        ApiResponse result = promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        assertNotNull(result);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getResponseCode());
+        assertEquals(Constants.FAILED, result.getParams().getStatus());
+        assertNotNull(result.getParams().getErrMsg());
         verify(objectMapper).readValue(eq(invalidJson), any(com.fasterxml.jackson.core.type.TypeReference.class));
     }
 
@@ -898,9 +900,11 @@ class PromotionalContentServiceImplTest {
                 anyList(),
                 isNull()
         )).thenThrow(new RuntimeException("Database connection failed"));
-        assertThrows(com.igot.cb.cassandra.exceptions.CustomException.class, () -> {
-            promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
-        });
+        ApiResponse result = promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        assertNotNull(result);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getResponseCode());
+        assertEquals(Constants.FAILED, result.getParams().getStatus());
+        assertNotNull(result.getParams().getErrMsg());
         verify(objectMapper, never()).readValue(anyString(), any(com.fasterxml.jackson.core.type.TypeReference.class));
     }
 
@@ -908,9 +912,11 @@ class PromotionalContentServiceImplTest {
     void testRead_ContentServiceException() {
         when(contentService.readCourseCategoryForContent(CONTENT_ID))
                 .thenThrow(new RuntimeException("Content service unavailable"));
-        assertThrows(com.igot.cb.cassandra.exceptions.CustomException.class, () -> {
-            promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
-        });
+        ApiResponse result = promotionalContentService.read(CONTENT_ID, AUTH_TOKEN);
+        assertNotNull(result);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getResponseCode());
+        assertEquals(Constants.FAILED, result.getParams().getStatus());
+        assertNotNull(result.getParams().getErrMsg());
         verify(cassandraOperation, never()).getRecordsByProperties(
                 anyString(), anyString(), any(), anyList(), any());
     }


### PR DESCRIPTION
1. Added the missing x-auth-token validation for the delete API.
2. Fixed all the breaking test cases.