### PR TITLE
KB-11901 | The "iGOT Specializations" section is not showing for the special designations.

### DIFF
--- a/src/main/java/com/igot/cb/cache/IdMapCacheMgr.java
+++ b/src/main/java/com/igot/cb/cache/IdMapCacheMgr.java
@@ -1,10 +1,11 @@
 package com.igot.cb.cache;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.collections4.MapUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -84,13 +85,13 @@ public class IdMapCacheMgr {
                     log.error("IdMapCacheMgr::getId: No response from ID Map service for keys: {}", batch);
                     break;
                 } else {
-                    for (Map<String, Integer> responseObject : response) {
-                        for (Map.Entry<String, Integer> entry : responseObject.entrySet()) {
-                            String key = entry.getKey().trim().toLowerCase();
-                            cacheMap.put(key, new CachedIdMap(entry.getValue(), defaultExpiryTime));
-                            result.put(key, entry.getValue());
-                        }
-                    }
+                    response.stream()
+                        .flatMap(responseObject -> responseObject.entrySet().stream())
+                        .forEach(entry -> {
+                            String decodedKey = decodeKey(entry.getKey());
+                            cacheMap.put(decodedKey, new CachedIdMap(entry.getValue(), defaultExpiryTime));
+                            result.put(decodedKey, entry.getValue());
+                        });
                 }
                 log.info("IdMapCacheMgr::getId: request url : {}, response: {}", uri.toString(), result);
             }
@@ -104,5 +105,15 @@ public class IdMapCacheMgr {
             batches.add(missingKeys.subList(i, Math.min(i + batchSize, missingKeys.size())));
         }
         return batches;
+    }
+
+    /**
+     * Decodes a URL-encoded key and normalizes it to lowercase.
+     *
+     * @param encodedKey The URL-encoded key from ID-Mapping service
+     * @return Decoded and normalized key
+     */
+    private String decodeKey(String encodedKey) {
+        return URLDecoder.decode(encodedKey, StandardCharsets.UTF_8).trim().toLowerCase();
     }
 }

--- a/src/test/java/com/igot/cb/cache/IdMapCacheMgrTest.java
+++ b/src/test/java/com/igot/cb/cache/IdMapCacheMgrTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -171,5 +172,232 @@ class IdMapCacheMgrTest {
         assertEquals(2, result.size());
         assertEquals(1, result.get(key1));
         assertEquals(2, result.get(key2));
+    }
+
+    @Test
+    void testGetId_withUrlEncodedSpaces_decodesCorrectly() {
+        String encodedKey = "assistant%20engineer"; // Encoded: "assistant engineer"
+        String expectedDecodedKey = "assistant engineer";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 100);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Assistant Engineer"));
+        assertEquals(1, result.size());
+        assertEquals(100, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_withUrlEncodedParentheses_decodesCorrectly() {
+        String encodedKey = "assistant%20%28signal%20and%20s%26t%29"; // "assistant (signal and s&t)"
+        String expectedDecodedKey = "assistant (signal and s&t)";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 200);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Assistant (Signal and S&T)"));
+        assertEquals(1, result.size());
+        assertEquals(200, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_withUrlEncodedPlusSign_decodesCorrectly() {
+        String encodedKey = "grade%2Ba"; // "grade+a"
+        String expectedDecodedKey = "grade+a";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 300);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Grade+A"));
+        assertEquals(1, result.size());
+        assertEquals(300, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_withUrlEncodedSpecialChars_decodesCorrectly() {
+        String encodedKey = "path%2Fto%3Aresource%2Citem%3Bvalue"; // "path/to:resource,item;value"
+        String expectedDecodedKey = "path/to:resource,item;value";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 400);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Path/To:Resource,Item;Value"));
+        assertEquals(1, result.size());
+        assertEquals(400, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_withUrlEncodedAmpersand_decodesCorrectly() {
+        String encodedKey = "research%20%26%20development"; // "research & development"
+        String expectedDecodedKey = "research & development";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 500);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Research & Development"));
+        assertEquals(1, result.size());
+        assertEquals(500, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_withUrlEncodedPercentSign_decodesCorrectly() {
+        String encodedKey = "discount%2550"; // "discount%50"
+        String expectedDecodedKey = "discount%50";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 600);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Discount%50"));
+        assertEquals(1, result.size());
+        assertEquals(600, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_withMixedEncodedAndPlainKeys_decodesCorrectly() {
+        String encodedKey1 = "senior%20manager"; // "senior manager"
+        String plainKey2 = "director"; // plain key
+        Map<String, Integer> mockResponse1 = new HashMap<>();
+        mockResponse1.put(encodedKey1, 700);
+        Map<String, Integer> mockResponse2 = new HashMap<>();
+        mockResponse2.put(plainKey2, 800);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse1, mockResponse2));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Senior Manager", "Director"));
+        assertEquals(2, result.size());
+        assertEquals(700, result.get("senior manager"));
+        assertEquals(800, result.get("director"));
+    }
+
+    @Test
+    void testGetId_withEncodedKeyInCache_returnsFromCache() throws Exception {
+        String decodedKey = "assistant (signal and s&t)";
+        CachedIdMap cachedEntry = new CachedIdMap(999, System.currentTimeMillis());
+        putInCache(decodedKey, cachedEntry);
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Assistant (Signal and S&T)"));
+        assertEquals(1, result.size());
+        assertEquals(999, result.get("Assistant (Signal and S&T)"));
+        verify(outboundRequestHandlerService, never()).fetchResultUsingExchange(anyString(), 
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any());
+    }
+
+    @Test
+    void testGetId_withUrlEncodedHashSymbol_decodesCorrectly() {
+        String encodedKey = "department%23001"; // "department#001"
+        String expectedDecodedKey = "department#001";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 1100);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Department#001"));
+        assertEquals(1, result.size());
+        assertEquals(1100, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_withUrlEncodedAtSymbol_decodesCorrectly() {
+        String encodedKey = "user%40domain"; // "user@domain"
+        String expectedDecodedKey = "user@domain";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 1200);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("User@Domain"));
+        assertEquals(1, result.size());
+        assertEquals(1200, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_streamProcessing_handlesMultipleResponseObjects() {
+        String key1 = "encoded%20key1";
+        String key2 = "encoded%20key2";
+        String key3 = "encoded%20key3";
+        Map<String, Integer> response1 = new HashMap<>();
+        response1.put(key1, 10);
+        response1.put(key2, 20);
+        Map<String, Integer> response2 = new HashMap<>();
+        response2.put(key3, 30);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(response1, response2));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Encoded Key1", "Encoded Key2", "Encoded Key3"));
+        assertEquals(3, result.size());
+        assertEquals(10, result.get("encoded key1"));
+        assertEquals(20, result.get("encoded key2"));
+        assertEquals(30, result.get("encoded key3"));
+    }
+
+    @Test
+    void testGetId_withWhitespaceAndEncoding_normalizesProperly() {
+        String encodedKey = "%20%20assistant%20engineer%20%20"; // "  assistant engineer  "
+        String expectedDecodedKey = "assistant engineer"; // trimmed and lowercase
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 1300);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("  Assistant Engineer  "));
+        assertEquals(1, result.size());
+        assertEquals(1300, result.get(expectedDecodedKey));
+    }
+
+    @Test
+    void testGetId_batchProcessing_withEncodedKeys() {
+        List<String> keys = new java.util.ArrayList<>();
+        Map<String, Integer> mockResponse1 = new HashMap<>();
+        Map<String, Integer> mockResponse2 = new HashMap<>();
+        for (int i = 1; i <= 60; i++) {
+            keys.add("Key" + i);
+            String encodedKey = "key" + i; // Service returns lowercase
+            if (i <= 50) {
+                mockResponse1.put(encodedKey, i);
+            } else {
+                mockResponse2.put(encodedKey, i);
+            }
+        }
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse1))
+                .thenReturn(List.of(mockResponse2));
+        Map<String, Integer> result = idMapCacheMgr.getId(keys);
+        assertEquals(60, result.size());
+        verify(outboundRequestHandlerService, times(2)).fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any());
+    }
+
+    @Test
+    void testGetId_withEncodedEqualsSign_decodesCorrectly() {
+        String encodedKey = "formula%3Da%2Bb"; // "formula=a+b"
+        String expectedDecodedKey = "formula=a+b";
+        Map<String, Integer> mockResponse = new HashMap<>();
+        mockResponse.put(encodedKey, 1400);
+        when(outboundRequestHandlerService.fetchResultUsingExchange(
+                anyString(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<Map<String, Integer>>>>any()))
+                .thenReturn(List.of(mockResponse));
+        Map<String, Integer> result = idMapCacheMgr.getId(List.of("Formula=A+B"));
+        assertEquals(1, result.size());
+        assertEquals(1400, result.get(expectedDecodedKey));
     }
 }


### PR DESCRIPTION
1.  Decoding the encoded values for the attribtutes and adding it to the cache.
2. Updated the JUnit test cases.