### PR TITLE
KB-11901 | L0 Organisation Access Settings Do Not Auto-Apply to ChildKB-11901 | L0 Organisation Access Settings Do Not Auto-Apply to Child Departments (Hierarchy Not Supported)

### DIFF
--- a/src/main/java/com/igot/cb/service/UserAndOrgServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/UserAndOrgServiceImpl.java
@@ -182,6 +182,8 @@ public class UserAndOrgServiceImpl {
                 }
             }
             checkUserTaggedUnderRozgarMela(userProfile, profileDetails);
+            putIfNotNullOrEmpty(userProfile, Constants.MINISTRY_OR_STATEID, (String) profileDetails.get(Constants.MINISTRY_OR_STATEID));
+            putIfNotNullOrEmpty(userProfile, Constants.MINISTRY_OR_STATETYPE, (String) profileDetails.get(Constants.MINISTRY_OR_STATETYPE));
         }
     }
 

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -491,6 +491,8 @@ public class Constants {
     public static final String PARTNER_ID = "partnerId";
     public static final String CB_PORES_SERVICE_HOST = "cbpores.service.host";
     public static final String EXTERNAL_CONTENT_READ_END_POINT = "external.content.read.endpoint";
+    public static final String MINISTRY_OR_STATEID = "ministryOrStateId";
+    public static final String MINISTRY_OR_STATETYPE = "ministryOrStateType";
     private Constants() {
     }
 }


### PR DESCRIPTION


1.  MInistryOrStateId , MinistryOrState Type added in the promotional content rule setting.