### PR TITLE
 KB-12170 | BE|DEV| Create new API for listing the Microcredentials content

### DIFF
--- a/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
+++ b/src/main/java/com/igot/cb/cache/PromotionalContentRuleCacheMgr.java
@@ -26,7 +26,7 @@ public class PromotionalContentRuleCacheMgr {
     private final CassandraOperation cassandraOperation;
     private final CbExtServerProperties properties;
     Map<String, CachedAccessSettingRule> cacheMap = new ConcurrentHashMap<>();
-    @Value("${promotional.content.cache.ttl.milliseconds}")
+    @Value("${promotional.content.rules.cache.expiry.ms}")
     private Integer promotionalContentCacheTtlMiliSeconds;
     /**
      * Constructs the cache manager with required dependencies.

--- a/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/PromotionalContentServiceImpl.java
@@ -14,7 +14,7 @@ import com.igot.cb.util.PayloadValidation;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.keycloak.common.util.CollectionUtil;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -44,7 +44,7 @@ public class PromotionalContentServiceImpl implements IPromotionalContentService
     @Value("${promotional.content.read.fields}")
     private String contentReadFields;
 
-    @Value("${promotional.content.cache.ttl.seconds}")
+    @Value("${promotional.content.user.cache.ttl.seconds}")
     private Integer promotionalContentCacheTtlSeconds;
 
     /**

--- a/src/main/java/com/igot/cb/util/CbExtServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbExtServerProperties.java
@@ -64,9 +64,6 @@ public class CbExtServerProperties {
     @Value("${cb.wrapper.notification.path}")
     private String cbWrapperNotificationPath;
 
-    @Value("${promotional.content.cache.ttl.minutes}")
-    private int promotionalContentCacheTtlMinutes;
-
     @Value("${promotional.content.cache.max.size}")
     private int promotionalContentCacheMaxSize;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -94,17 +94,16 @@ cb.wrapper.notification.host=http://cb-notification-wrapper-service:8081/
 cb.wrapper.notification.path=notifications/create
 
 # Promotional Content Cache Configuration
-promotional.content.cache.ttl.minutes=60
 promotional.content.cache.max.size=5000
 promotional.content.cache.warming.enabled=true
 promotional.content.cache.batch.size=500
 promotional.content.cache.max.query.size=5000
-promotional.content.cache.ttl.seconds=14400
-promotional.content.cache.ttl.milliseconds=120000
+promotional.content.user.cache.ttl.seconds=14400
+promotional.content.rules.cache.expiry.ms=14400000
 promotional.content.read.fields=identifier,courseCategory,contentType,posterImage,mediaType,reviewStatus,status,batches,creatorLogo,language,organisation,primaryCategory,name,avgRating,programDuration
 
 # User Profile Tag Configuration (e.g., for Rozgar Mela)
-user.profile.tag.values=Rozgar Mela
+user.profile.tag.value=Rozgar Mela
 user.profile.tag.bitmap.key=rozgarMelaTag
 
 cios.search.limit=100
@@ -113,4 +112,3 @@ cios.integration.search.host=http://localhost:7002
 cios.integration.search=/ciosIntegration/v1/search/content
 external.content.read.endpoint=/cios/v1/content/read
 cbpores.service.host=http://localhost:7001
-user.profile.tag.value=

--- a/src/test/java/com/igot/cb/cache/PromotionalContentRuleCacheMgrTest.java
+++ b/src/test/java/com/igot/cb/cache/PromotionalContentRuleCacheMgrTest.java
@@ -29,7 +29,6 @@ class PromotionalContentRuleCacheMgrTest {
 
     @BeforeEach
     void setup() {
-        lenient().when(properties.getPromotionalContentCacheTtlMinutes()).thenReturn(60);
         lenient().when(properties.getPromotionalContentCacheMaxSize()).thenReturn(5000);
         lenient().when(properties.isPromotionalContentCacheWarmingEnabled()).thenReturn(false);
         lenient().when(properties.getPromotionalContentCacheBatchSize()).thenReturn(500);


### PR DESCRIPTION
1. Renamed the cache key.
2. Removed the unused cache key.