### PR TITLE
KAR-1134:Regarding Moderated Courses Not Visible in CBP Plan for DoPT

### DIFF
--- a/src/main/java/com/igot/cb/service/CbPlanLearnerServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/CbPlanLearnerServiceImpl.java
@@ -279,7 +279,7 @@ public class CbPlanLearnerServiceImpl {
 
             if (MapUtils.isNotEmpty(contentDetails)) {
                 if (courseId.contains("_rc")) {
-                    if (Constants.VERIFIED.equalsIgnoreCase(userProfile.get(Constants.PROFILE_STATUS_KEY))) {
+                    if (Constants.VERIFIED.equalsIgnoreCase(userProfile.get(Constants.PROFILE_STATUS_LOWER_KEY))) {
                         Object secureSettingsObj = contentDetails.get(Constants.SECURE_SETTINGS);
                         if (secureSettingsObj instanceof Map<?, ?> secureSettings && !secureSettings.isEmpty()) {
                             Object orgListObj = secureSettings.get(Constants.ORGANISATION);


### PR DESCRIPTION
When comparing the user's profile status to determine whether to add a moderated course to the get cbplan list, the code was incorrectly using "profileStatus" instead of the correct key, which is "profilestatus." The variable userProfile contains the accurate key for the profile status value.

<img width="1920" height="1080" alt="Screenshot from 2026-01-07 17-35-31" src="https://github.com/user-attachments/assets/ca2a07a7-fa55-43f7-a621-7ee315850c03" />
