### PR TITLE
KB-14310 added API for content dictionary

### DIFF
--- a/src/main/java/com/igot/cb/service/ContentDictionaryService.java
+++ b/src/main/java/com/igot/cb/service/ContentDictionaryService.java
@@ -7,11 +7,13 @@ import com.igot.cb.model.ApiResponse;
 import com.igot.cb.util.Constants;
 import com.igot.cb.util.ProjectUtil;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Service class for handling operations related to Content Dictionary.
@@ -29,30 +31,61 @@ public class ContentDictionaryService {
     }
 
     /**
-     * Reads the content dictionary from Redis key "content_dictionary"
+     * Reads the content dictionary from Redis HASH "content_dictionary_v2"
      * and constructs the API Response.
+     * <p>
+     * Response structure is maintained for backward compatibility with UI.
      *
      * @return ApiResponse containing the content dictionary as result map or error status.
      */
     public ApiResponse getContentDictionary() {
         ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_CONTENT_DICTIONARY_READ);
         try {
-            String value = redisCacheMgr.getFromCache(Constants.REDIS_CONTENT_DICTIONARY_KEY);
-            if (StringUtils.isBlank(value)) {
-                log.warn("ContentDictionaryService::getContentDictionary - Content dictionary key '{}' not found or empty in Redis", Constants.REDIS_CONTENT_DICTIONARY_KEY);
+            log.debug("ContentDictionaryService::getContentDictionary - Fetching from Redis HASH: {}", Constants.REDIS_CONTENT_DICTIONARY_KEY);
+            Map<String, String> hashData = redisCacheMgr.getAllCachedAccessRules(Constants.REDIS_CONTENT_DICTIONARY_KEY);
+            if (MapUtils.isEmpty(hashData)) {
+                log.warn("ContentDictionaryService::getContentDictionary - Content dictionary HASH '{}' not found or empty in Redis", Constants.REDIS_CONTENT_DICTIONARY_KEY);
                 ProjectUtil.setFailedResponse(response, "Content dictionary not found in cache", HttpStatus.NOT_FOUND);
                 return response;
             }
-
-            Map<String, Object> dictionary = objectMapper.readValue(value, new TypeReference<Map<String, Object>>() {});
-            
+            Map<String, Object> dictionary = new HashMap<>();
+            hashData.forEach((identifier, jsonValue) ->
+                parseHashItem(identifier, jsonValue)
+                    .ifPresent(itemData -> dictionary.put(identifier, itemData))
+            );
+            if (dictionary.isEmpty()) {
+                log.error("ContentDictionaryService::getContentDictionary - No valid items found after parsing");
+                ProjectUtil.setFailedResponse(response, "Content dictionary is empty or corrupted", HttpStatus.INTERNAL_SERVER_ERROR);
+                return response;
+            }
             response.setResult(dictionary);
             response.setResponseCode(HttpStatus.OK);
-            log.info("ContentDictionaryService::getContentDictionary - Successfully retrieved content dictionary");
+            log.info("ContentDictionaryService::getContentDictionary - Successfully retrieved {} items from content dictionary",
+                    dictionary.size());
         } catch (Exception e) {
             log.error("ContentDictionaryService::getContentDictionary - Error retrieving content dictionary from Redis", e);
             ProjectUtil.setFailedResponse(response, "Failed to read content dictionary: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
         return response;
+    }
+
+
+    /**
+     * Parse a single item from Redis HASH field.
+     *
+     * @param identifier The item identifier
+     * @param jsonValue  The JSON string value
+     * @return Optional containing parsed Map, empty if parsing fails
+     */
+    private Optional<Map<String, Object>> parseHashItem(String identifier, String jsonValue) {
+        try {
+            Map<String, Object> parsedData = objectMapper.readValue(jsonValue, new TypeReference<>() {
+            });
+            return Optional.of(parsedData);
+        } catch (Exception parseException) {
+            log.warn("ContentDictionaryService::parseHashItem - Failed to parse JSON for identifier: {}, error: {}",
+                    identifier, parseException.getMessage());
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -601,7 +601,7 @@ public class Constants {
     public static final String CONSUMPTION_RECORDS = "consumptionRecords";
     
     // Content Dictionary Constants
-    public static final String REDIS_CONTENT_DICTIONARY_KEY = "content_dictionary";
+    public static final String REDIS_CONTENT_DICTIONARY_KEY = "content_dictionary_v2";
     public static final String API_CONTENT_DICTIONARY_READ = "api.content.dictionary.read";
     public static final String PERSONAL_CONTENT_INFO_REDIS_KEY_PREFIX = "personalContentInfo_";
     public static final String MODERATED_COURSE_COUNT_REDIS_KEY_PREFIX = "moderatedCourseCount_";

--- a/src/test/java/com/igot/cb/service/ContentDictionaryServiceTest.java
+++ b/src/test/java/com/igot/cb/service/ContentDictionaryServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -35,23 +36,29 @@ class ContentDictionaryServiceTest {
 
     @Test
     void testGetContentDictionary_Success() throws Exception {
-        Map<String, Object> testMap = Map.of("key1", "value1", "key2", 123);
-        String jsonValue = objectMapper.writeValueAsString(testMap);
-
-        when(redisCacheMgr.getFromCache(Constants.REDIS_CONTENT_DICTIONARY_KEY)).thenReturn(jsonValue);
-
+        Map<String, Object> item1Data = Map.of("name", "Course 1", "identifier", "do_123");
+        Map<String, Object> item2Data = Map.of("name", "Course 2", "identifier", "do_456");
+        String item1Json = objectMapper.writeValueAsString(item1Data);
+        String item2Json = objectMapper.writeValueAsString(item2Data);
+        Map<String, String> hashData = new HashMap<>();
+        hashData.put("do_123", item1Json);
+        hashData.put("do_456", item2Json);
+        when(redisCacheMgr.getAllCachedAccessRules(Constants.REDIS_CONTENT_DICTIONARY_KEY)).thenReturn(hashData);
         ApiResponse response = contentDictionaryService.getContentDictionary();
-
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertEquals(Constants.SUCCESS, response.getParams().getStatus());
-        assertEquals("value1", response.getResult().get("key1"));
-        assertEquals(123, response.getResult().get("key2"));
+        Map<String, Object> resultDict = (Map<String, Object>) response.getResult();
+        assertEquals(2, resultDict.size());
+        Map<String, Object> item1 = (Map<String, Object>) resultDict.get("do_123");
+        assertEquals("Course 1", item1.get("name"));
+        Map<String, Object> item2 = (Map<String, Object>) resultDict.get("do_456");
+        assertEquals("Course 2", item2.get("name"));
     }
 
     @Test
     void testGetContentDictionary_CacheEmpty() {
-        when(redisCacheMgr.getFromCache(Constants.REDIS_CONTENT_DICTIONARY_KEY)).thenReturn(null);
+        when(redisCacheMgr.getAllCachedAccessRules(Constants.REDIS_CONTENT_DICTIONARY_KEY)).thenReturn(null);
 
         ApiResponse response = contentDictionaryService.getContentDictionary();
 
@@ -62,14 +69,44 @@ class ContentDictionaryServiceTest {
     }
 
     @Test
-    void testGetContentDictionary_InvalidJson() {
-        when(redisCacheMgr.getFromCache(Constants.REDIS_CONTENT_DICTIONARY_KEY)).thenReturn("invalid-json");
+    void testGetContentDictionary_EmptyHashMap() {
+        when(redisCacheMgr.getAllCachedAccessRules(Constants.REDIS_CONTENT_DICTIONARY_KEY)).thenReturn(new HashMap<>());
 
         ApiResponse response = contentDictionaryService.getContentDictionary();
 
         assertNotNull(response);
+        assertEquals(HttpStatus.NOT_FOUND, response.getResponseCode());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals("Content dictionary not found in cache", response.getParams().getErrMsg());
+    }
+
+    @Test
+    void testGetContentDictionary_InvalidJson() throws Exception {
+        Map<String, String> hashData = new HashMap<>();
+        hashData.put("do_123", "invalid-json");
+        when(redisCacheMgr.getAllCachedAccessRules(Constants.REDIS_CONTENT_DICTIONARY_KEY)).thenReturn(hashData);
+        ApiResponse response = contentDictionaryService.getContentDictionary();
+        assertNotNull(response);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
         assertEquals(Constants.FAILED, response.getParams().getStatus());
-        assertNotNull(response.getParams().getErrMsg());
+        assertEquals("Content dictionary is empty or corrupted", response.getParams().getErrMsg());
+    }
+
+    @Test
+    void testGetContentDictionary_PartialInvalidJson() throws Exception {
+        Map<String, Object> validItemData = Map.of("name", "Valid Course", "identifier", "do_123");
+        String validJson = objectMapper.writeValueAsString(validItemData);
+        Map<String, String> hashData = new HashMap<>();
+        hashData.put("do_123", validJson);
+        hashData.put("do_456", "invalid-json");
+        when(redisCacheMgr.getAllCachedAccessRules(Constants.REDIS_CONTENT_DICTIONARY_KEY)).thenReturn(hashData);
+        ApiResponse response = contentDictionaryService.getContentDictionary();
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        Map<String, Object> resultDict = response.getResult();
+        assertEquals(1, resultDict.size());
+        Map<String, Object> validItem = (Map<String, Object>) resultDict.get("do_123");
+        assertEquals("Valid Course", validItem.get("name"));
     }
 }


### PR DESCRIPTION
refactor: migrate content dictionary to Redis HASH structure

## Summary
- Migrate from Redis JSON blob to HASH structure for content_dictionary_v2
- Improve code quality by extracting methods and using functional patterns
- Maintain backward-compatible API response structure

## Changes

### Service Layer (ContentDictionaryService.java)
- Changed data source from `getFromCache()` to `getAllCachedAccessRules()` for HASH support
- Extracted `parseHashItem()` method to eliminate nested try-catch blocks
- Return `Optional<Map<String, Object>>` instead of null for safer parsing
- Implemented stream-based processing using `forEach()` and `ifPresent()`
- Used `MapUtils.isEmpty()` for cleaner null/empty checks
- Removed success/failure counters from logging

### Constants (Constants.java)
- Updated REDIS_CONTENT_DICTIONARY_KEY from "content_dictionary" to "content_dictionary_v2"

### Test Suite
- Updated ContentDictionaryServiceTest with 5 comprehensive test cases:
  - Success case with multiple HASH entries
  - Null cache handling
  - Empty HashMap handling
  - Complete invalid JSON (all items fail)
  - Partial invalid JSON (graceful degradation)
- All tests passing (5/5 service, 1/1 controller)

## Technical Details
- Response structure unchanged - maintains UI compatibility
- HASH format: key=identifier, value=JSON string per content item
- Graceful error handling - invalid items logged but don't break entire response
- Reduced cognitive complexity via method extraction