### PR TITLE
KB-14847 | BE| support portal API for orgEligibility - upsert and rea…

### DIFF
--- a/src/main/java/com/igot/cb/controller/OrgEligibilityController.java
+++ b/src/main/java/com/igot/cb/controller/OrgEligibilityController.java
@@ -1,0 +1,43 @@
+package com.igot.cb.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.service.OrgEligibilityServiceImpl;
+import com.igot.cb.util.Constants;
+
+@RestController
+@RequestMapping("/orgeligibility/v1")
+public class OrgEligibilityController {
+
+    private final OrgEligibilityServiceImpl orgEligibilityService;
+
+    public OrgEligibilityController(OrgEligibilityServiceImpl orgEligibilityService) {
+        this.orgEligibilityService = orgEligibilityService;
+    }
+
+    @PostMapping("/upsert")
+    public ResponseEntity<ApiResponse> upsertOrgEligibility(
+            @RequestBody Map<String, Object> request,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token) {
+        ApiResponse response = orgEligibilityService.upsertOrgEligibility(request, token);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+    @GetMapping("/read/{orgId}")
+    public ResponseEntity<ApiResponse> readOrgEligibility(
+            @PathVariable("orgId") String orgId,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token) {
+        ApiResponse response = orgEligibilityService.readOrgEligibility(orgId, token);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+}

--- a/src/main/java/com/igot/cb/elasticsearch/config/EsConfig.java
+++ b/src/main/java/com/igot/cb/elasticsearch/config/EsConfig.java
@@ -32,9 +32,31 @@ public class EsConfig {
     @Value("${elasticsearch.password}")
     private String elasticsearchPassword;
 
+    @Value("${org.eligibility.elasticsearch.host}")
+    private String orgEligibilityElasticsearchHost;
+
+    @Value("${org.eligibility.elasticsearch.port}")
+    private int orgEligibilityElasticsearchPort;
+
+    @Value("${org.eligibility.elasticsearch.username}")
+    private String orgEligibilityElasticsearchUsername;
+
+    @Value("${org.eligibility.elasticsearch.password}")
+    private String orgEligibilityElasticsearchPassword;
+
     @Bean(name = "elasticsearchClient")
     public ElasticsearchClient elasticsearchClient() {
         return createClient(elasticsearchHost, elasticsearchPort, elasticsearchUsername, elasticsearchPassword);
+    }
+
+    /**
+     * The org_eligibility_alias index lives on a separate ES cluster from cb_plan_v2 in some
+     * environments, so it gets its own client rather than sharing "elasticsearchClient".
+     */
+    @Bean(name = "orgEligibilityElasticsearchClient")
+    public ElasticsearchClient orgEligibilityElasticsearchClient() {
+        return createClient(orgEligibilityElasticsearchHost, orgEligibilityElasticsearchPort,
+                orgEligibilityElasticsearchUsername, orgEligibilityElasticsearchPassword);
     }
 
     private ElasticsearchClient createClient(String host, int port, String username, String password) {

--- a/src/main/java/com/igot/cb/elasticsearch/service/EsUtilService.java
+++ b/src/main/java/com/igot/cb/elasticsearch/service/EsUtilService.java
@@ -1,5 +1,6 @@
 package com.igot.cb.elasticsearch.service;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.igot.cb.elasticsearch.dto.SearchCriteria;
 import com.igot.cb.elasticsearch.dto.SearchResult;
 
@@ -9,7 +10,13 @@ public interface EsUtilService {
 
     String addDocument(String esIndexName, String type, String id, Map<String, Object> document, String JsonFilePath);
 
+    String addDocument(ElasticsearchClient client, String esIndexName, String type, String id, Map<String, Object> document, String JsonFilePath);
+
     String updateDocument(String index, String indexType, String entityId, Map<String, Object> document, String JsonFilePath);
 
     SearchResult searchDocuments(String esIndexName, SearchCriteria searchCriteria, String elasticCbPlanJsonPath) throws Exception;
+
+    Map<String, Object> getDocumentById(String esIndexName, String id);
+
+    Map<String, Object> getDocumentById(ElasticsearchClient client, String esIndexName, String id);
 }

--- a/src/main/java/com/igot/cb/elasticsearch/service/EsUtilServiceImpl.java
+++ b/src/main/java/com/igot/cb/elasticsearch/service/EsUtilServiceImpl.java
@@ -57,6 +57,12 @@ public class EsUtilServiceImpl implements EsUtilService{
     @Override
     public String addDocument(
             String esIndexName, String type, String id, Map<String, Object> document, String JsonFilePath) {
+        return addDocument(elasticsearchClient, esIndexName, type, id, document, JsonFilePath);
+    }
+
+    @Override
+    public String addDocument(ElasticsearchClient client, String esIndexName, String type, String id,
+            Map<String, Object> document, String JsonFilePath) {
         logger.info("EsUtilServiceImpl :: addDocument");
         try {
             JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance();
@@ -78,7 +84,7 @@ public class EsUtilServiceImpl implements EsUtilService{
                     .document(document)
                     .refresh(Refresh.True)
                     .build();
-            IndexResponse response = elasticsearchClient.index(indexRequest);
+            IndexResponse response = client.index(indexRequest);
             return "Successfully indexed document with id: " + response.result();
         } catch (Exception e) {
             logger.error("Issue while Indexing to es: {}", e.getMessage());
@@ -126,6 +132,25 @@ public class EsUtilServiceImpl implements EsUtilService{
             return (existingFound ? "updated" : "created") + ":" + response.result().jsonValue();
         } catch (Exception e) {
             log.error("Error performing merge+index update for index={}, id={}: {}", index, entityId, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    @Override
+    public Map<String, Object> getDocumentById(String esIndexName, String id) {
+        return getDocumentById(elasticsearchClient, esIndexName, id);
+    }
+
+    @Override
+    public Map<String, Object> getDocumentById(ElasticsearchClient client, String esIndexName, String id) {
+        try {
+            GetResponse<Object> response = client.get(builder -> builder.index(esIndexName).id(id), Object.class);
+            if (response.found() && response.source() instanceof Map) {
+                return (Map<String, Object>) response.source();
+            }
+            return null;
+        } catch (Exception e) {
+            log.error("Error fetching document by id from ES. index={}, id={}: {}", esIndexName, id, e.getMessage(), e);
             return null;
         }
     }

--- a/src/main/java/com/igot/cb/service/OrgEligibilityServiceImpl.java
+++ b/src/main/java/com/igot/cb/service/OrgEligibilityServiceImpl.java
@@ -1,0 +1,109 @@
+package com.igot.cb.service;
+
+import java.util.Map;
+
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.igot.cb.elasticsearch.service.EsUtilService;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.AccessTokenValidator;
+import com.igot.cb.util.CbExtServerProperties;
+import com.igot.cb.util.Constants;
+import com.igot.cb.util.ProjectUtil;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class OrgEligibilityServiceImpl {
+
+    private final EsUtilService esUtilService;
+    private final CbExtServerProperties serverProperties;
+    private final ElasticsearchClient orgEligibilityElasticsearchClient;
+    private final AccessTokenValidator accessTokenValidator;
+
+    public OrgEligibilityServiceImpl(EsUtilService esUtilService, CbExtServerProperties serverProperties,
+            @Qualifier("orgEligibilityElasticsearchClient") ElasticsearchClient orgEligibilityElasticsearchClient,
+            AccessTokenValidator accessTokenValidator) {
+        this.esUtilService = esUtilService;
+        this.serverProperties = serverProperties;
+        this.orgEligibilityElasticsearchClient = orgEligibilityElasticsearchClient;
+        this.accessTokenValidator = accessTokenValidator;
+    }
+
+    public ApiResponse upsertOrgEligibility(Map<String, Object> request, String authToken) {
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_ORG_ELIGIBILITY_UPSERT);
+        try {
+            String userId = accessTokenValidator.fetchUserIdFromAccessToken(authToken, response);
+            if (StringUtils.isBlank(userId)) {
+                return response;
+            }
+
+            String orgId = (String) request.get(Constants.ORG_ID);
+            if (StringUtils.isBlank(orgId)) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr("orgId is missing in request");
+                response.setResponseCode(HttpStatus.BAD_REQUEST);
+                return response;
+            }
+
+            String result = esUtilService.addDocument(orgEligibilityElasticsearchClient,
+                    serverProperties.getOrgEligibilityIndex(), Constants.INDEX_TYPE,
+                    orgId, request, serverProperties.getElasticOrgEligibilityJsonPath());
+            if (StringUtils.isBlank(result)) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr("Failed to upsert org eligibility for orgId: " + orgId);
+                response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+                return response;
+            }
+
+            response.getResult().put(Constants.ORG_ID, orgId);
+            response.getResult().put(Constants.STATUS, Constants.SUCCESS);
+        } catch (Exception e) {
+            log.error("Failed to upsert org eligibility", e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(e.getMessage());
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return response;
+    }
+
+    public ApiResponse readOrgEligibility(String orgId, String authToken) {
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_ORG_ELIGIBILITY_READ);
+        try {
+            String userId = accessTokenValidator.fetchUserIdFromAccessToken(authToken, response);
+            if (StringUtils.isBlank(userId)) {
+                return response;
+            }
+
+            if (StringUtils.isBlank(orgId)) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr("orgId is missing");
+                response.setResponseCode(HttpStatus.BAD_REQUEST);
+                return response;
+            }
+
+            Map<String, Object> document = esUtilService.getDocumentById(orgEligibilityElasticsearchClient,
+                    serverProperties.getOrgEligibilityIndex(), orgId);
+            if (MapUtils.isEmpty(document)) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr("Org eligibility not found for orgId: " + orgId);
+                response.setResponseCode(HttpStatus.BAD_REQUEST);
+                return response;
+            }
+
+            response.getResult().putAll(document);
+        } catch (Exception e) {
+            log.error("Failed to read org eligibility for orgId: " + orgId, e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(e.getMessage());
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/igot/cb/util/CbExtServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbExtServerProperties.java
@@ -25,6 +25,12 @@ public class CbExtServerProperties {
     @Value("${elastic.required.field.cb.plan.json.path}")
     private String elasticCbPlanJsonPath;
 
+    @Value("${org.eligibility.index}")
+    private String orgEligibilityIndex;
+
+    @Value("${elastic.required.field.org.eligibility.json.path}")
+    private String elasticOrgEligibilityJsonPath;
+
     @Value("${msg.on.user.group.restriction.for.all.org}")
     private String msgOnUserGroupRestrictionForAllOrg;
 

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -199,6 +199,10 @@ public class Constants {
     public static final String ORG_REDIX_KEY = "org:";
     public static final String ORG_ID = "orgId";
     public static final String API_POPULAR_COMMUNITY = "api.popular communities";
+    public static final String COURSE_IDS = "courseIds";
+    public static final String COURSE_COUNT = "courseCount";
+    public static final String API_ORG_ELIGIBILITY_UPSERT = "api.org.eligibility.upsert";
+    public static final String API_ORG_ELIGIBILITY_READ = "api.org.eligibility.read";
     public static final String COUNT_OF_COMMUNITIES = "countOfCommunities";
     public static final String TOPIC_IS_INACTIVE = "Topic is inactive";
     public static final String DRAFT = "draft";

--- a/src/main/resources/EsRequiredFields/EsRequiredFieldsOrgEligibility.json
+++ b/src/main/resources/EsRequiredFields/EsRequiredFieldsOrgEligibility.json
@@ -1,0 +1,17 @@
+{
+  "orgId": {
+    "type": "keyword"
+  },
+  "courseIds": {
+    "type": "keyword"
+  },
+  "courseCount": {
+    "type": "long"
+  },
+  "version": {
+    "type": "long"
+  },
+  "updatedAt": {
+    "type": "date"
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,10 +54,16 @@ elasticsearch.host=localhost
 elasticsearch.port=9201
 elasticsearch.username=
 elasticsearch.password=
+org.eligibility.elasticsearch.host=localhost
+org.eligibility.elasticsearch.port=9201
+org.eligibility.elasticsearch.username=
+org.eligibility.elasticsearch.password=
 cb.plan.v2.index=cb_plan_v2
 msg.on.user.group.restriction.for.all.org=User groups must either target a specific organisation or apply without an organisation (which refers to All Organisations). Both options cannot be combined in the same configuration.
 cb.plan.batch.size=5
 non.text.fields=isApar,createdAt,endDate
+org.eligibility.index=org_eligibility_alias
+elastic.required.field.org.eligibility.json.path=/EsRequiredFields/EsRequiredFieldsOrgEligibility.json
 
 learning_service_vm_base_url=http://localhost:8080/learning-service
 system.content.update.url=/system/v3/content/update/

--- a/src/test/java/com/igot/cb/controller/OrgEligibilityControllerTest.java
+++ b/src/test/java/com/igot/cb/controller/OrgEligibilityControllerTest.java
@@ -1,0 +1,104 @@
+package com.igot.cb.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.service.OrgEligibilityServiceImpl;
+import com.igot.cb.util.Constants;
+
+@ExtendWith(MockitoExtension.class)
+class OrgEligibilityControllerTest {
+
+    @Mock
+    private OrgEligibilityServiceImpl orgEligibilityService;
+
+    @InjectMocks
+    private OrgEligibilityController controller;
+
+    private static final String AUTH_TOKEN = "Bearer test-token";
+    private static final String ORG_ID = "0146196505889341440";
+
+    private Map<String, Object> requestBody;
+
+    @BeforeEach
+    void setUp() {
+        requestBody = new HashMap<>();
+        requestBody.put(Constants.ORG_ID, ORG_ID);
+        requestBody.put(Constants.COURSE_COUNT, 1);
+    }
+
+    @Test
+    void testUpsertOrgEligibility_Success() {
+        ApiResponse mockResponse = ApiResponse.createDefaultResponse(Constants.API_ORG_ELIGIBILITY_UPSERT);
+        mockResponse.getResult().put(Constants.ORG_ID, ORG_ID);
+        when(orgEligibilityService.upsertOrgEligibility(anyMap(), anyString())).thenReturn(mockResponse);
+
+        ResponseEntity<ApiResponse> response = controller.upsertOrgEligibility(requestBody, AUTH_TOKEN);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(ORG_ID, response.getBody().getResult().get(Constants.ORG_ID));
+        verify(orgEligibilityService, times(1)).upsertOrgEligibility(requestBody, AUTH_TOKEN);
+    }
+
+    @Test
+    void testUpsertOrgEligibility_Failure() {
+        ApiResponse mockResponse = ApiResponse.createDefaultResponse(Constants.API_ORG_ELIGIBILITY_UPSERT);
+        mockResponse.getParams().setStatus(Constants.FAILED);
+        mockResponse.getParams().setErr("orgId is missing in request");
+        mockResponse.setResponseCode(HttpStatus.BAD_REQUEST);
+        when(orgEligibilityService.upsertOrgEligibility(anyMap(), anyString())).thenReturn(mockResponse);
+
+        ResponseEntity<ApiResponse> response = controller.upsertOrgEligibility(new HashMap<>(), AUTH_TOKEN);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(Constants.FAILED, response.getBody().getParams().getStatus());
+    }
+
+    @Test
+    void testReadOrgEligibility_Success() {
+        ApiResponse mockResponse = ApiResponse.createDefaultResponse(Constants.API_ORG_ELIGIBILITY_READ);
+        mockResponse.getResult().put(Constants.ORG_ID, ORG_ID);
+        mockResponse.getResult().put(Constants.COURSE_COUNT, 10);
+        when(orgEligibilityService.readOrgEligibility(ORG_ID, AUTH_TOKEN)).thenReturn(mockResponse);
+
+        ResponseEntity<ApiResponse> response = controller.readOrgEligibility(ORG_ID, AUTH_TOKEN);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(ORG_ID, response.getBody().getResult().get(Constants.ORG_ID));
+        verify(orgEligibilityService, times(1)).readOrgEligibility(ORG_ID, AUTH_TOKEN);
+    }
+
+    @Test
+    void testReadOrgEligibility_NotFound() {
+        ApiResponse mockResponse = ApiResponse.createDefaultResponse(Constants.API_ORG_ELIGIBILITY_READ);
+        mockResponse.getParams().setStatus(Constants.FAILED);
+        mockResponse.getParams().setErr("Org eligibility not found for orgId: " + ORG_ID);
+        mockResponse.setResponseCode(HttpStatus.BAD_REQUEST);
+        when(orgEligibilityService.readOrgEligibility(ORG_ID, AUTH_TOKEN)).thenReturn(mockResponse);
+
+        ResponseEntity<ApiResponse> response = controller.readOrgEligibility(ORG_ID, AUTH_TOKEN);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(Constants.FAILED, response.getBody().getParams().getStatus());
+    }
+}

--- a/src/test/java/com/igot/cb/service/OrgEligibilityServiceImplTest.java
+++ b/src/test/java/com/igot/cb/service/OrgEligibilityServiceImplTest.java
@@ -1,0 +1,189 @@
+package com.igot.cb.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.igot.cb.elasticsearch.service.EsUtilService;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.AccessTokenValidator;
+import com.igot.cb.util.CbExtServerProperties;
+import com.igot.cb.util.Constants;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OrgEligibilityServiceImplTest {
+
+    @Mock
+    private EsUtilService esUtilService;
+
+    @Mock
+    private CbExtServerProperties serverProperties;
+
+    @Mock
+    private ElasticsearchClient orgEligibilityElasticsearchClient;
+
+    @Mock
+    private AccessTokenValidator accessTokenValidator;
+
+    private OrgEligibilityServiceImpl orgEligibilityService;
+
+    private static final String AUTH_TOKEN = "test-token";
+    private static final String ORG_ID = "0146196505889341440";
+
+    @BeforeEach
+    void setUp() {
+        orgEligibilityService = new OrgEligibilityServiceImpl(esUtilService, serverProperties,
+                orgEligibilityElasticsearchClient, accessTokenValidator);
+        when(serverProperties.getOrgEligibilityIndex()).thenReturn("org_eligibility_alias");
+        when(serverProperties.getElasticOrgEligibilityJsonPath())
+                .thenReturn("/EsRequiredFields/EsRequiredFieldsOrgEligibility.json");
+    }
+
+    private Map<String, Object> buildValidRequest() {
+        Map<String, Object> request = new HashMap<>();
+        request.put(Constants.ORG_ID, ORG_ID);
+        request.put(Constants.COURSE_IDS, java.util.List.of("do_1145741849"));
+        request.put(Constants.COURSE_COUNT, 1);
+        request.put(Constants.VERSION, 1);
+        request.put(Constants.UPDATED_AT, "2026-06-25T10:00:00Z");
+        return request;
+    }
+
+    @Test
+    void testUpsertOrgEligibility_UnauthorizedToken() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("");
+
+        ApiResponse response = orgEligibilityService.upsertOrgEligibility(buildValidRequest(), AUTH_TOKEN);
+
+        assertNotNull(response);
+        verify(esUtilService, never()).addDocument(any(), anyString(), anyString(), anyString(), any(), anyString());
+    }
+
+    @Test
+    void testUpsertOrgEligibility_MissingOrgId() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+
+        ApiResponse response = orgEligibilityService.upsertOrgEligibility(new HashMap<>(), AUTH_TOKEN);
+
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        verify(esUtilService, never()).addDocument(any(), anyString(), anyString(), anyString(), any(), anyString());
+    }
+
+    @Test
+    void testUpsertOrgEligibility_Success() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(esUtilService.addDocument(any(ElasticsearchClient.class), anyString(), anyString(), eqOrgId(),
+                any(), anyString())).thenReturn("Successfully indexed document with id: Created");
+
+        ApiResponse response = orgEligibilityService.upsertOrgEligibility(buildValidRequest(), AUTH_TOKEN);
+
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        assertEquals(ORG_ID, response.getResult().get(Constants.ORG_ID));
+        assertEquals(Constants.SUCCESS, response.getResult().get(Constants.STATUS));
+    }
+
+    @Test
+    void testUpsertOrgEligibility_EsFailure() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(esUtilService.addDocument(any(ElasticsearchClient.class), anyString(), anyString(), eqOrgId(),
+                any(), anyString())).thenReturn(null);
+
+        ApiResponse response = orgEligibilityService.upsertOrgEligibility(buildValidRequest(), AUTH_TOKEN);
+
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    @Test
+    void testUpsertOrgEligibility_ExceptionHandling() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(serverProperties.getOrgEligibilityIndex()).thenThrow(new RuntimeException("config error"));
+
+        ApiResponse response = orgEligibilityService.upsertOrgEligibility(buildValidRequest(), AUTH_TOKEN);
+
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    @Test
+    void testReadOrgEligibility_UnauthorizedToken() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("");
+
+        ApiResponse response = orgEligibilityService.readOrgEligibility(ORG_ID, AUTH_TOKEN);
+
+        assertNotNull(response);
+        verify(esUtilService, never()).getDocumentById(any(), anyString(), anyString());
+    }
+
+    @Test
+    void testReadOrgEligibility_BlankOrgId() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+
+        ApiResponse response = orgEligibilityService.readOrgEligibility("", AUTH_TOKEN);
+
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        verify(esUtilService, never()).getDocumentById(any(), anyString(), anyString());
+    }
+
+    @Test
+    void testReadOrgEligibility_NotFound() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(esUtilService.getDocumentById(any(ElasticsearchClient.class), anyString(), eqOrgId())).thenReturn(null);
+
+        ApiResponse response = orgEligibilityService.readOrgEligibility(ORG_ID, AUTH_TOKEN);
+
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testReadOrgEligibility_Success() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        Map<String, Object> document = buildValidRequest();
+        when(esUtilService.getDocumentById(any(ElasticsearchClient.class), anyString(), eqOrgId()))
+                .thenReturn(document);
+
+        ApiResponse response = orgEligibilityService.readOrgEligibility(ORG_ID, AUTH_TOKEN);
+
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        assertEquals(ORG_ID, response.getResult().get(Constants.ORG_ID));
+        assertEquals(1, response.getResult().get(Constants.COURSE_COUNT));
+    }
+
+    @Test
+    void testReadOrgEligibility_ExceptionHandling() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("user1");
+        when(serverProperties.getOrgEligibilityIndex()).thenThrow(new RuntimeException("config error"));
+
+        ApiResponse response = orgEligibilityService.readOrgEligibility(ORG_ID, AUTH_TOKEN);
+
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    private String eqOrgId() {
+        return org.mockito.ArgumentMatchers.eq(ORG_ID);
+    }
+}


### PR DESCRIPTION
…d APIs (#297)

* KB-14847 | BE| support portal API for orgEligibility - upsert and read APIs

* KB-14847 | BE| ES required field schema for orgEligibility index



* KB-14847 | BE| orgEligibility controller and service with auth token validation



* KB-14847 | BE| add test cases for orgEligibility controller and service



---------