### PR TITLE
KB-15093 | DEV |BE | Implementation of the APIs for creating the Training Plans

### DIFF
--- a/src/main/java/com/igot/cb/cache/CbPlanCacheMgrV3.java
+++ b/src/main/java/com/igot/cb/cache/CbPlanCacheMgrV3.java
@@ -1,0 +1,277 @@
+package com.igot.cb.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.util.Constants;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * Cache Manager for CB Plan V3 with year-scoped caching.
+ * Implements Caffeine + Cassandra two-tier caching pattern.
+ *
+ * @version 3.0
+ */
+@Component
+@Slf4j
+public class CbPlanCacheMgrV3 {
+    @Value("${cb.plan.v3.cache.ttl.minutes:60}")
+    private int ttlMinutes;
+    @Value("${cb.plan.v3.batch.size:5}")
+    private int planBatchSize;
+    @Value("${cb.plan.v3.caffine.cache.max.size:5000}")
+    private int maxCacheSize;
+    private final CassandraOperation cassandraOperation;
+    private Cache<String, List<Map<String, Object>>> cbPlanCache;
+    private Cache<String, Map<String, Object>> planIdCache;
+
+    public CbPlanCacheMgrV3(CassandraOperation cassandraOperation) {
+        this.cassandraOperation = cassandraOperation;
+    }
+
+    @PostConstruct
+    public void initCache() {
+        this.cbPlanCache = Caffeine.newBuilder()
+                .maximumSize(maxCacheSize)
+                .expireAfterWrite(Duration.ofMinutes(ttlMinutes))
+                .build();
+        this.planIdCache = Caffeine.newBuilder()
+                .maximumSize(maxCacheSize)
+                .expireAfterWrite(Duration.ofMinutes(ttlMinutes))
+                .build();
+        log.info("Initialized CbPlanCacheMgrV3 with TTL: {} minutes, max size: {}", ttlMinutes, maxCacheSize);
+    }
+
+    /**
+     * Gets CB Plans visible to all organizations for a specific plan year.
+     *
+     * @param planYear the plan year (e.g., "2026-27")
+     * @return list of active CB Plans visible to all orgs, or empty list if none
+     */
+    public List<Map<String, Object>> getCbPlanForAllOrgs(String planYear) {
+        String cacheKey = "all-lookup:" + planYear;
+        List<Map<String, Object>> allCbPlanList = cbPlanCache.getIfPresent(cacheKey);
+        if (Objects.isNull(allCbPlanList)) {
+            log.debug("getCbPlanForAllOrgs: Caffeine cache miss - planYear={}", planYear);
+            Map<String, Object> propertiesMap = Map.of(Constants.PLAN_YEAR, planYear);
+            allCbPlanList = cassandraOperation.getRecordsByProperties(
+                    Constants.KEYSPACE_SUNBIRD,
+                    Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ALL_ORG,
+                    propertiesMap,
+                    List.of(),
+                    null);
+            if (Objects.isNull(allCbPlanList)) {
+                log.warn("getCbPlanForAllOrgs: Cassandra returned null - planYear={}", planYear);
+                allCbPlanList = new ArrayList<>();
+            }
+            allCbPlanList = allCbPlanList.stream()
+                    .filter(plan -> Boolean.TRUE.equals(plan.get(Constants.IS_ACTIVE)))
+                    .toList();
+            cbPlanCache.put(cacheKey, allCbPlanList);
+            log.info("getCbPlanForAllOrgs: Loaded from Cassandra - planYear={}, activeCount={}",
+                    planYear, allCbPlanList.size());
+        } else {
+            log.debug("getCbPlanForAllOrgs: Caffeine cache hit - planYear={}, count={}",
+                    planYear, allCbPlanList.size());
+        }
+        return allCbPlanList;
+    }
+
+    /**
+     * Gets CB Plans for a specific organization and plan year.
+     *
+     * @param orgId    the organization ID
+     * @param planYear the plan year (e.g., "2026-27")
+     * @return list of active CB Plans for this org, or empty list if none
+     */
+    public List<Map<String, Object>> getCbPlanForOrgId(String orgId, String planYear) {
+        String cacheKey = orgId + "-lookup:" + planYear;
+        List<Map<String, Object>> cbPlanList = cbPlanCache.getIfPresent(cacheKey);
+        if (Objects.isNull(cbPlanList)) {
+            log.debug("getCbPlanForOrgId: Caffeine cache miss - orgId={}, planYear={}", orgId, planYear);
+            Map<String, Object> propertiesMap = Map.of(
+                    Constants.ORG_ID, orgId,
+                    Constants.PLAN_YEAR, planYear);
+            cbPlanList = cassandraOperation.getRecordsByProperties(
+                    Constants.KEYSPACE_SUNBIRD,
+                    Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ORG,
+                    propertiesMap,
+                    List.of(),
+                    null);
+            if (Objects.isNull(cbPlanList)) {
+                log.warn("getCbPlanForOrgId: Cassandra returned null - orgId={}, planYear={}", orgId, planYear);
+                cbPlanList = new ArrayList<>();
+            }
+            cbPlanList = cbPlanList.stream()
+                    .filter(plan -> Boolean.TRUE.equals(plan.get(Constants.IS_ACTIVE)))
+                    .toList();
+            cbPlanCache.put(cacheKey, cbPlanList);
+            log.info("getCbPlanForOrgId: Loaded from Cassandra - orgId={}, planYear={}, activeCount={}",
+                    cbPlanList.size(), orgId, planYear);
+        } else {
+            log.debug("getCbPlanForOrgId: Caffeine cache hit - orgId={}, planYear={}, count={}",
+                    orgId, planYear, cbPlanList.size());
+        }
+        return cbPlanList;
+    }
+
+    /**
+     * Gets all CB Plans for a user's org and plan year (org-specific + all-org plans).
+     *
+     * @param orgId          the user's organization ID
+     * @param planYear       the plan year
+     * @param isCacheEnabled flag to indicate if result came from cache
+     * @return combined list of active LIVE CB Plans
+     */
+    public List<Map<String, Object>> getCbPlanForAllAndOrgId(String orgId, String planYear,
+                                                             AtomicBoolean isCacheEnabled) {
+        String cacheKey = orgId + ":" + planYear;
+        List<Map<String, Object>> activeCbPlans = cbPlanCache.getIfPresent(cacheKey);
+        if (CollectionUtils.isNotEmpty(activeCbPlans)) {
+            log.info("Cache hit for orgId: {}, planYear: {}, found {} active CB Plans", orgId, planYear, activeCbPlans.size());
+            isCacheEnabled.set(true);
+            return activeCbPlans;
+        }
+        List<Map<String, Object>> orgPlans = getCbPlanForOrgId(orgId, planYear);
+        List<Map<String, Object>> allOrgPlans = getCbPlanForAllOrgs(planYear);
+        List<Map<String, Object>> combinedList = new ArrayList<>(orgPlans);
+        combinedList.addAll(allOrgPlans);
+        if (combinedList.isEmpty()) {
+            log.info("No CB Plans found for orgId: {}, planYear: {}", orgId, planYear);
+            cbPlanCache.put(cacheKey, new ArrayList<>());
+            return new ArrayList<>();
+        }
+        Map<String, Map<String, Object>> planMap = combinedList.stream()
+                .filter(m -> Objects.nonNull(m.get(Constants.END_DATE_REQUEST)) && Objects.nonNull(m.get(Constants.PLAN_ID)))
+                .collect(Collectors.toMap(
+                        m -> (String) m.get(Constants.PLAN_ID),
+                        m -> m,
+                        (existing, replacement) -> existing
+                ));
+        List<Map<String, Object>> dedupedList = planMap.values().stream()
+                .sorted(Comparator.comparing(
+                        m -> (Instant) m.get(Constants.END_DATE_REQUEST),
+                        Comparator.nullsLast(Comparator.reverseOrder())
+                ))
+                .toList();
+        List<String> planIds = dedupedList.stream()
+                .map(plan -> (String) plan.get(Constants.PLAN_ID))
+                .toList();
+        List<Map<String, Object>> fullPlans = getCbPlansByPlanIdsInBatch(planIds);
+        activeCbPlans = fullPlans.stream()
+                .filter(plan -> Constants.LIVE.equalsIgnoreCase((String) plan.get(Constants.STATUS)))
+                .toList();
+        log.info("Found {} CB Plans for orgId: {}, planYear: {}, active LIVE count: {}",
+                fullPlans.size(), orgId, planYear, activeCbPlans.size());
+        cbPlanCache.put(cacheKey, activeCbPlans);
+        isCacheEnabled.set(true);
+        return activeCbPlans;
+    }
+
+    /**
+     * Fetches full CB Plan records by plan IDs in batches.
+     *
+     * @param planIds list of plan IDs to fetch
+     * @return list of full CB Plan records
+     */
+    public List<Map<String, Object>> getCbPlansByPlanIdsInBatch(List<String> planIds) {
+        if (CollectionUtils.isEmpty(planIds)) {
+            log.warn("getCbPlansByPlanIdsInBatch: Empty plan ID list");
+            return new ArrayList<>();
+        }
+        List<Map<String, Object>> allCbPlans = new ArrayList<>();
+        List<String> missingPlanIds = collectCachedPlans(planIds, allCbPlans);
+        if (missingPlanIds.isEmpty()) {
+            log.debug("getCbPlansByPlanIdsInBatch: Full cache hit - count={}", planIds.size());
+            return allCbPlans;
+        }
+        log.debug("getCbPlansByPlanIdsInBatch: Fetching from Cassandra - missing={}, batchSize={}",
+                missingPlanIds.size(), planBatchSize);
+        fetchMissingPlansInBatches(missingPlanIds, allCbPlans);
+        log.info("getCbPlansByPlanIdsInBatch: Total={}, fromCache={}, fromCassandra={}",
+                allCbPlans.size(), planIds.size() - missingPlanIds.size(),
+                allCbPlans.size() - (planIds.size() - missingPlanIds.size()));
+        return allCbPlans;
+    }
+
+    /**
+     * Collects cached plans and returns list of missing plan IDs.
+     *
+     * @param planIds    input plan IDs
+     * @param allCbPlans accumulator for cached plans
+     * @return list of plan IDs not found in cache
+     */
+    private List<String> collectCachedPlans(List<String> planIds, List<Map<String, Object>> allCbPlans) {
+        List<String> missingPlanIds = new ArrayList<>();
+        for (String planId : planIds) {
+            Map<String, Object> cachedPlan = planIdCache.getIfPresent(planId);
+            if (Objects.nonNull(cachedPlan)) {
+                allCbPlans.add(cachedPlan);
+            } else {
+                missingPlanIds.add(planId);
+            }
+        }
+        return missingPlanIds;
+    }
+
+    /**
+     * Fetches missing plans from Cassandra in configured batch sizes.
+     *
+     * @param missingPlanIds plan IDs to fetch
+     * @param allCbPlans     accumulator for fetched plans
+     */
+    private void fetchMissingPlansInBatches(List<String> missingPlanIds, List<Map<String, Object>> allCbPlans) {
+        for (int i = 0; i < missingPlanIds.size(); i += planBatchSize) {
+            List<String> batch = missingPlanIds.subList(i, Math.min(i + planBatchSize, missingPlanIds.size()));
+            fetchSingleBatch(batch, allCbPlans);
+        }
+    }
+
+    /**
+     * Fetches a single batch of plans from Cassandra and caches them.
+     *
+     * @param batch      batch of plan IDs
+     * @param allCbPlans accumulator for fetched plans
+     */
+    private void fetchSingleBatch(List<String> batch, List<Map<String, Object>> allCbPlans) {
+        Map<String, Object> propertiesMap = Map.of(Constants.PLAN_ID, batch);
+        try {
+            List<Map<String, Object>> batchResult = cassandraOperation.getRecordsByProperties(
+                    Constants.KEYSPACE_SUNBIRD,
+                    Constants.TABLE_CB_PLAN_V3,
+                    propertiesMap,
+                    List.of(),
+                    null);
+            if (CollectionUtils.isNotEmpty(batchResult)) {
+                allCbPlans.addAll(batchResult);
+                cacheBatchResults(batchResult);
+            }
+        } catch (Exception e) {
+            log.error("getCbPlansByPlanIdsInBatch: Failed to fetch batch - ids={}", batch, e);
+        }
+    }
+
+    /**
+     * Caches batch results to planIdCache.
+     *
+     * @param batchResult plans fetched from Cassandra
+     */
+    private void cacheBatchResults(List<Map<String, Object>> batchResult) {
+        for (Map<String, Object> plan : batchResult) {
+            String id = (String) plan.get(Constants.PLAN_ID);
+            if (Objects.nonNull(id)) {
+                planIdCache.put(id, plan);
+            }
+        }
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/controller/CbPlanWithAccessSettingsV3.java
+++ b/src/main/java/com/igot/cb/cbplan/controller/CbPlanWithAccessSettingsV3.java
@@ -1,0 +1,151 @@
+package com.igot.cb.cbplan.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.igot.cb.cbplan.service.CbPlanServiceV3;
+import com.igot.cb.elasticsearch.dto.SearchCriteria;
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.Constants;
+
+/**
+ * REST Controller for CB Plan V3 operations with Access Settings.
+ *
+ * @version 3.0
+ */
+@RestController
+@RequestMapping("/cbplan/v3")
+public class CbPlanWithAccessSettingsV3 {
+    private final CbPlanServiceV3 cbPlanServiceV3;
+
+    public CbPlanWithAccessSettingsV3(CbPlanServiceV3 cbPlanServiceV3) {
+        this.cbPlanServiceV3 = cbPlanServiceV3;
+    }
+
+    /**
+     * Creates a new CB Plan.
+     *
+     * @param request   the API request containing CB Plan details
+     * @param token     the authentication token
+     * @param userOrgId the organization ID of the user
+     * @return ResponseEntity containing ApiResponse with created plan details
+     */
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse> createCbPlan(
+            @RequestBody ApiRequest request,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token,
+            @RequestHeader(Constants.X_AUTH_USER_ORG_ID) String userOrgId) {
+        ApiResponse response = cbPlanServiceV3.createCbPlan(request, userOrgId, token);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+    /**
+     * Updates an existing CB Plan.
+     *
+     * @param request   the API request containing updated CB Plan details
+     * @param token     the authentication token
+     * @param userOrgId the organization ID of the user
+     * @param userRoles the roles of the user
+     * @return ResponseEntity containing ApiResponse with update status
+     */
+    @PostMapping("/update")
+    public ResponseEntity<ApiResponse> updateCbPlan(
+            @RequestBody ApiRequest request,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token,
+            @RequestHeader(Constants.X_AUTH_USER_ORG_ID) String userOrgId,
+            @RequestHeader(Constants.X_AUTH_USER_ROLES) List<String> userRoles) {
+        ApiResponse response = cbPlanServiceV3.updateCbPlan(request, userOrgId, token, userRoles);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+    /**
+     * Publishes a CB Plan.
+     *
+     * @param request   the API request containing CB Plan ID and comment
+     * @param token     the authentication token
+     * @param userOrgId the organization ID of the user
+     * @param userRoles the roles of the user
+     * @return ResponseEntity containing ApiResponse with publish status
+     */
+    @PostMapping("/publish")
+    public ResponseEntity<ApiResponse> publishCbPlan(
+            @RequestBody ApiRequest request,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token,
+            @RequestHeader(Constants.X_AUTH_USER_ORG_ID) String userOrgId,
+            @RequestHeader(Constants.X_AUTH_USER_ROLES) List<String> userRoles) {
+        ApiResponse response = cbPlanServiceV3.publishCbPlan(request, userOrgId, token, userRoles);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+    /**
+     * Archives (retires) a CB Plan.
+     *
+     * @param request   the API request containing CB Plan ID and comment
+     * @param token     the authentication token
+     * @param userOrgId the organization ID of the user
+     * @param userRoles the roles of the user
+     * @return ResponseEntity containing ApiResponse with archive status
+     */
+    @DeleteMapping("/archive")
+    public ResponseEntity<ApiResponse> retireCbPlan(
+            @RequestBody ApiRequest request,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token,
+            @RequestHeader(Constants.X_AUTH_USER_ORG_ID) String userOrgId,
+            @RequestHeader(Constants.X_AUTH_USER_ROLES) List<String> userRoles) {
+        ApiResponse response = cbPlanServiceV3.retireCbPlan(request, userOrgId, token, userRoles);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+    /**
+     * Reads a CB Plan by ID with enriched content details.
+     *
+     * @param cbPlanId  the CB Plan ID to retrieve
+     * @param token     the authentication token
+     * @param userOrgId the organization ID of the user
+     * @return ResponseEntity containing ApiResponse with CB Plan details
+     */
+    @GetMapping("/read/{cbPlanId}")
+    public ResponseEntity<ApiResponse> readCbPlan(
+            @PathVariable("cbPlanId") String cbPlanId,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token,
+            @RequestHeader(Constants.X_AUTH_USER_ORG_ID) String userOrgId) {
+        ApiResponse response = cbPlanServiceV3.readCbPlan(cbPlanId, userOrgId, token);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+    /**
+     * Searches CB Plans based on criteria.
+     *
+     * @param request   the search criteria
+     * @param token     the authentication token
+     * @param userOrgId the organization ID of the user
+     * @return ResponseEntity containing ApiResponse with search results
+     */
+    @PostMapping("/search")
+    public ResponseEntity<ApiResponse> searchCbPlan(
+            @RequestBody SearchCriteria request,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token,
+            @RequestHeader(Constants.X_AUTH_USER_ORG_ID) String userOrgId) {
+        ApiResponse response = cbPlanServiceV3.searchCbPlan(request, userOrgId, token);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+
+    /**
+     * Gets CB Plan dictionary for a user - content IDs grouped by APAR/non-APAR
+     * with plan occurrences and optional enrichment.
+     *
+     * @param request the API request containing planYear and enrichment
+     * @param token   the authentication token
+     * @return ResponseEntity containing ApiResponse with content dictionary
+     */
+    @PostMapping("/user/dictionary")
+    public ResponseEntity<ApiResponse> getCBPlanDictionary(
+            @RequestBody ApiRequest request,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String token) {
+        ApiResponse response = cbPlanServiceV3.getCBPlanDictionaryForUser(request, token);
+        return new ResponseEntity<>(response, response.getResponseCode());
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/dto/CbPlanContentOccurrence.java
+++ b/src/main/java/com/igot/cb/cbplan/dto/CbPlanContentOccurrence.java
@@ -1,0 +1,33 @@
+package com.igot.cb.cbplan.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * Represents a single occurrence of a content item in a CB Plan.
+ * Used to track which plans contain a particular course and when they expire.
+ *
+ * @author CB Ext Team
+ * @version 3.0
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CbPlanContentOccurrence {
+
+    /**
+     * CB Plan ID where this content appears.
+     */
+    @JsonProperty("planId")
+    private String planId;
+
+    /**
+     * End date of the plan (when this content assignment expires).
+     */
+    @JsonProperty("endDate")
+    private Instant endDate;
+}

--- a/src/main/java/com/igot/cb/cbplan/dto/CbPlanDictionaryCacheEntry.java
+++ b/src/main/java/com/igot/cb/cbplan/dto/CbPlanDictionaryCacheEntry.java
@@ -1,0 +1,45 @@
+package com.igot.cb.cbplan.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cache entry for user CB Plan dictionary responses.
+ * Stores computed APAR/non-APAR grouping results (excludes enrichment).
+ *
+ * @version 3.0
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CbPlanDictionaryCacheEntry {
+
+    /**
+     * Map of APAR content IDs to their plan occurrences.
+     */
+    @JsonProperty("aparContentList")
+    private Map<String, List<CbPlanContentOccurrence>> aparContentList;
+
+    /**
+     * Map of non-APAR content IDs to their plan occurrences.
+     */
+    @JsonProperty("nonAparContentList")
+    private Map<String, List<CbPlanContentOccurrence>> nonAparContentList;
+
+    /**
+     * Count of unique APAR content IDs.
+     */
+    @JsonProperty("aparCount")
+    private int aparCount;
+
+    /**
+     * Count of unique non-APAR content IDs.
+     */
+    @JsonProperty("nonAparCount")
+    private int nonAparCount;
+}

--- a/src/main/java/com/igot/cb/cbplan/dto/CbPlanReadResponseDto.java
+++ b/src/main/java/com/igot/cb/cbplan/dto/CbPlanReadResponseDto.java
@@ -1,0 +1,99 @@
+package com.igot.cb.cbplan.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DTO for CB Plan V3 read response.
+ * Contains all plan details including enriched content information.
+ *
+ * @version 3.0
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CbPlanReadResponseDto {
+
+    /**
+     * CB Plan unique identifier.
+     */
+    private String id;
+
+    /**
+     * Plan name.
+     */
+    private String name;
+
+    /**
+     * Financial year for the plan (e.g., "2026-27").
+     */
+    private String planYear;
+
+    /**
+     * Plan end date.
+     */
+    private Instant endDate;
+
+    /**
+     * Whether this is an APAR (Annual Performance Appraisal Report) plan.
+     */
+    private Boolean isApar;
+
+    /**
+     * Content type (e.g., "Course", "Program").
+     */
+    private String contentType;
+
+    /**
+     * Plan type classification.
+     */
+    private String planType;
+
+    /**
+     * Timestamp when the plan was created.
+     */
+    private Instant createdAt;
+
+    /**
+     * Timestamp when the plan was published.
+     */
+    private Instant cbPublishedAt;
+
+    /**
+     * Plan status (DRAFT, LIVE, ARCHIVED).
+     */
+    private String status;
+
+    /**
+     * User ID of the creator.
+     */
+    private String createdBy;
+
+    /**
+     * Name of the creator.
+     */
+    private String createdByName;
+
+    /**
+     * Context data containing access control settings and user groups.
+     */
+    private JsonNode contextData;
+
+    /**
+     * List of enriched content items with metadata.
+     * Each map contains content details like identifier, name, description, etc.
+     */
+    private List<Map<String, Object>> contentList;
+}

--- a/src/main/java/com/igot/cb/cbplan/service/CbPlanServiceV3.java
+++ b/src/main/java/com/igot/cb/cbplan/service/CbPlanServiceV3.java
@@ -1,0 +1,87 @@
+package com.igot.cb.cbplan.service;
+
+import java.util.List;
+
+import com.igot.cb.elasticsearch.dto.SearchCriteria;
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+
+/**
+ * Service interface for CB Plan V3 operations.
+ *
+ * @version 3.0
+ */
+public interface CbPlanServiceV3 {
+    /**
+     * Creates a new CB Plan.
+     *
+     * @param request   the API request containing CB Plan details
+     * @param userOrgId the organization ID of the user
+     * @param authToken the authentication token
+     * @return ApiResponse containing the created plan ID and status
+     */
+    ApiResponse createCbPlan(ApiRequest request, String userOrgId, String authToken);
+
+    /**
+     * Updates an existing CB Plan.
+     *
+     * @param request   the API request containing updated CB Plan details
+     * @param userOrgId the organization ID of the user
+     * @param authToken the authentication token
+     * @param userRoles the roles of the user
+     * @return ApiResponse containing the update status
+     */
+    ApiResponse updateCbPlan(ApiRequest request, String userOrgId, String authToken, List<String> userRoles);
+
+    /**
+     * Publishes a CB Plan.
+     *
+     * @param request   the API request containing CB Plan ID and comment
+     * @param userOrgId the organization ID of the user
+     * @param authToken the authentication token
+     * @param userRoles the roles of the user
+     * @return ApiResponse containing the publish status
+     */
+    ApiResponse publishCbPlan(ApiRequest request, String userOrgId, String authToken, List<String> userRoles);
+
+    /**
+     * Archives (retires) a CB Plan.
+     *
+     * @param request   the API request containing CB Plan ID and comment
+     * @param userOrgId the organization ID of the user
+     * @param authToken the authentication token
+     * @param userRoles the roles of the user
+     * @return ApiResponse containing the archive status
+     */
+    ApiResponse retireCbPlan(ApiRequest request, String userOrgId, String authToken, List<String> userRoles);
+
+    /**
+     * Searches CB Plans based on criteria.
+     *
+     * @param searchCriteria the search criteria
+     * @param userOrgId      the organization ID of the user
+     * @param authToken      the authentication token
+     * @return ApiResponse containing search results
+     */
+    ApiResponse searchCbPlan(SearchCriteria searchCriteria, String userOrgId, String authToken);
+
+    /**
+     * Gets CB Plan dictionary for a user - content IDs grouped by APAR/non-APAR
+     * with plan occurrences and optional enrichment.
+     *
+     * @param request   the API request containing planYear and enrichment
+     * @param authToken the authentication token
+     * @return ApiResponse with aparContentList, nonAparContentList, and optionally enrichedContentList
+     */
+    ApiResponse getCBPlanDictionaryForUser(ApiRequest request, String authToken);
+
+    /**
+     * Reads a CB Plan by ID with enriched content details.
+     *
+     * @param cbPlanId     the CB Plan ID to retrieve
+     * @param userOrgId    the organization ID of the user
+     * @param authUserToken the authentication token
+     * @return ApiResponse containing the CB Plan details or error
+     */
+    ApiResponse readCbPlan(String cbPlanId, String userOrgId, String authUserToken);
+}

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanContentLookupServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanContentLookupServiceV3Impl.java
@@ -1,0 +1,427 @@
+package com.igot.cb.cbplan.service.impl;
+
+import java.util.*;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.igot.cb.cache.RedisCacheMgr;
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.service.OutboundRequestHandlerServiceImpl;
+import com.igot.cb.util.Constants;
+import com.igot.cb.util.PropertiesCache;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service for managing CB Plan content lookup table operations.
+ *
+ * @version 3.0
+ */
+@Service
+@Slf4j
+public class CbPlanContentLookupServiceV3Impl {
+    private final CassandraOperation cassandraOperation;
+    private final RedisCacheMgr redisCacheMgr;
+    private final OutboundRequestHandlerServiceImpl outboundRequestHandlerService;
+    private final PropertiesCache propertiesCache;
+    private final ObjectMapper mapper;
+
+    public CbPlanContentLookupServiceV3Impl(CassandraOperation cassandraOperation,
+                                            RedisCacheMgr redisCacheMgr,
+                                            OutboundRequestHandlerServiceImpl outboundRequestHandlerService) {
+        this.cassandraOperation = cassandraOperation;
+        this.redisCacheMgr = redisCacheMgr;
+        this.outboundRequestHandlerService = outboundRequestHandlerService;
+        this.propertiesCache = PropertiesCache.getInstance();
+        this.mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    /**
+     * Updates content lookup table for a CB Plan.
+     *
+     * @param planId   CB Plan ID
+     * @param planData CB Plan data containing content list
+     */
+    public void updateContentLookup(String planId, Map<String, Object> planData) {
+        log.debug("updateContentLookup: Entry - planId={}", planId);
+        List<String> contentIds = (List<String>) planData.get(Constants.CONTENT_LIST);
+        if (CollectionUtils.isEmpty(contentIds)) {
+            log.debug("updateContentLookup: No content to update - planId={}", planId);
+            return;
+        }
+        log.info("updateContentLookup: Updating lookup for planId={}, contentCount={}", planId, contentIds.size());
+        upsertCbPlanContentLookup(planId, contentIds);
+    }
+
+    /**
+     * Upserts content lookup entries for a CB Plan.
+     * Adds the plan ID to each content's plan set in the lookup table.
+     *
+     * @param planId     CB Plan ID
+     * @param contentIds list of content IDs
+     */
+    public void upsertCbPlanContentLookup(String planId, List<String> contentIds) {
+        log.debug("upsertCbPlanContentLookup: Processing - planId={}, contentCount={}", planId, contentIds.size());
+        int updated = 0;
+        int skipped = 0;
+        for (String contentId : contentIds) {
+            Map<String, Object> where = Map.of(Constants.CONTENT_ID_COLUMN, contentId);
+            Set<String> planIds = fetchExistingPlanIds(where);
+            if (!planIds.contains(planId)) {
+                planIds.add(planId);
+                updateContentLookupRecord(where, planIds);
+                updated++;
+            } else {
+                skipped++;
+            }
+        }
+        log.info("upsertCbPlanContentLookup: Completed - planId={}, updated={}, skipped={}",
+                planId, updated, skipped);
+    }
+
+    /**
+     * Updates content lookup for modified CB Plan.
+     * Handles content additions and deletions.
+     *
+     * @param cbPlanId       CB Plan ID
+     * @param updatedRequest updated request data
+     * @param existingCbPlan existing CB Plan data
+     */
+    public void updateContentLookupForModifiedPlan(String cbPlanId, Map<String, Object> updatedRequest,
+                                                   Map<String, Object> existingCbPlan) {
+        log.debug("updateContentLookupForModifiedPlan: Entry - planId={}", cbPlanId);
+        List<String> updatedContentIds = (List<String>) updatedRequest.get(Constants.CONTENT_LIST);
+        if (CollectionUtils.isEmpty(updatedContentIds)) {
+            log.debug("updateContentLookupForModifiedPlan: No updated content - planId={}", cbPlanId);
+            return;
+        }
+        List<String> existingContentIds = (List<String>) existingCbPlan.get(Constants.CONTENT_LIST);
+        List<String> addedContent = getAddedContent(existingContentIds, updatedContentIds);
+        List<String> deletedContent = getDeletedContent(existingContentIds, updatedContentIds);
+        log.info("updateContentLookupForModifiedPlan: planId={}, added={}, deleted={}",
+                cbPlanId, addedContent.size(), deletedContent.size());
+        if (CollectionUtils.isNotEmpty(addedContent)) {
+            log.debug("updateContentLookupForModifiedPlan: Upserting added content - planId={}, count={}",
+                    cbPlanId, addedContent.size());
+            upsertCbPlanContentLookup(cbPlanId, addedContent);
+        }
+        if (CollectionUtils.isNotEmpty(deletedContent)) {
+            log.debug("updateContentLookupForModifiedPlan: Removing deleted content - planId={}, count={}",
+                    cbPlanId, deletedContent.size());
+            removeCbPlanInfoForUpdateOrDeleteCbPlan(cbPlanId, deletedContent);
+        }
+    }
+
+    /**
+     * Removes CB Plan from all its content lookup entries.
+     *
+     * @param cbPlanId       CB Plan ID
+     * @param existingCbPlan existing CB Plan data
+     */
+    public void removeFromContentLookup(String cbPlanId, Map<String, Object> existingCbPlan) {
+        log.debug("removeFromContentLookup: Entry - planId={}", cbPlanId);
+        List<String> contentIds = (List<String>) existingCbPlan.get(Constants.CONTENT_LIST);
+        if (CollectionUtils.isEmpty(contentIds)) {
+            log.debug("removeFromContentLookup: No content to remove - planId={}", cbPlanId);
+            return;
+        }
+        log.info("removeFromContentLookup: Removing planId={} from {} content entries", cbPlanId, contentIds.size());
+        removeCbPlanInfoForUpdateOrDeleteCbPlan(cbPlanId, contentIds);
+    }
+
+    /**
+     * Removes CB Plan info from content lookup entries.
+     * Deletes row if it's the last plan, otherwise removes plan from the set.
+     *
+     * @param cbPlanId   CB Plan ID
+     * @param contentIds list of content IDs
+     */
+    public void removeCbPlanInfoForUpdateOrDeleteCbPlan(String cbPlanId, List<String> contentIds) {
+        log.debug("removeCbPlanInfoForUpdateOrDeleteCbPlan: Entry - planId={}, contentCount={}",
+                cbPlanId, contentIds.size());
+        int deleted = 0;
+        int updated = 0;
+        int skipped = 0;
+        for (String contentId : contentIds) {
+            Map<String, Object> where = Map.of(Constants.CONTENT_ID_COLUMN, contentId);
+            List<Map<String, Object>> rows = cassandraOperation.getRecordsByProperties(
+                    Constants.KEYSPACE_SUNBIRD, Constants.TABLE_CB_PLAN_V3_CONTENT_LOOKUP,
+                    where, List.of(Constants.PLAN_ID_COLUMN), 1);
+            if (CollectionUtils.isEmpty(rows)) {
+                log.debug("removeCbPlanInfoForUpdateOrDeleteCbPlan: No row found - contentId={}", contentId);
+                skipped++;
+                continue;
+            }
+            String result = processContentLookupRemoval(cbPlanId, contentId, rows, where);
+            if (Constants.RESULT_DELETED.equals(result)) {
+                deleted++;
+            } else if (Constants.RESULT_UPDATED.equals(result)) {
+                updated++;
+            } else {
+                skipped++;
+            }
+        }
+        log.info("removeCbPlanInfoForUpdateOrDeleteCbPlan: Completed - planId={}, deleted={}, updated={}, skipped={}",
+                cbPlanId, deleted, updated, skipped);
+    }
+
+    /**
+     * Gets added content by comparing existing and updated content lists.
+     *
+     * @param existingContent existing content list
+     * @param updatedContent  updated content list
+     * @return list of added content IDs
+     */
+    public List<String> getAddedContent(List<String> existingContent, List<String> updatedContent) {
+        Set<String> existingSet = new HashSet<>(Objects.nonNull(existingContent) ? existingContent : List.of());
+        Set<String> updatedSet = new HashSet<>(Objects.nonNull(updatedContent) ? updatedContent : List.of());
+        updatedSet.removeAll(existingSet);
+        return new ArrayList<>(updatedSet);
+    }
+
+    /**
+     * Gets deleted content by comparing existing and updated content lists.
+     *
+     * @param existingContent existing content list
+     * @param updatedContent  updated content list
+     * @return list of deleted content IDs
+     */
+    public List<String> getDeletedContent(List<String> existingContent, List<String> updatedContent) {
+        Set<String> existingSet = new HashSet<>(Objects.nonNull(existingContent) ? existingContent : List.of());
+        Set<String> updatedSet = new HashSet<>(Objects.nonNull(updatedContent) ? updatedContent : List.of());
+        existingSet.removeAll(updatedSet);
+        return new ArrayList<>(existingSet);
+    }
+
+    /**
+     * Fetches existing plan IDs from content lookup table.
+     *
+     * @param where query criteria (content_id)
+     * @return set of plan IDs, or empty set if not found
+     */
+    private Set<String> fetchExistingPlanIds(Map<String, Object> where) {
+        Set<String> planIds = new HashSet<>();
+        List<Map<String, Object>> rows = cassandraOperation.getRecordsByProperties(
+                Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3_CONTENT_LOOKUP,
+                where,
+                List.of(Constants.PLAN_ID_COLUMN),
+                1);
+        if (CollectionUtils.isNotEmpty(rows)) {
+            Object existing = rows.get(0).get(Constants.PLAN_ID);
+            if (existing instanceof Set) {
+                planIds.addAll((Set<String>) existing);
+            }
+        }
+        return planIds;
+    }
+
+    /**
+     * Updates content lookup record with new plan IDs set.
+     *
+     * @param where   query criteria (content_id)
+     * @param planIds updated set of plan IDs
+     */
+    private void updateContentLookupRecord(Map<String, Object> where, Set<String> planIds) {
+        Map<String, Object> update = Map.of(Constants.PLAN_ID_COLUMN, planIds);
+        cassandraOperation.updateRecord(
+                Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3_CONTENT_LOOKUP,
+                update,
+                where);
+    }
+
+    /**
+     * Processes content lookup removal.
+     * Deletes row if it's the last plan, otherwise updates the plan set.
+     *
+     * @param cbPlanId  CB Plan ID to remove
+     * @param contentId content ID
+     * @param rows      existing rows from query
+     * @param where     query criteria
+     * @return Constants.RESULT_DELETED, RESULT_UPDATED, or RESULT_SKIPPED
+     */
+    private String processContentLookupRemoval(String cbPlanId, String contentId,
+                                               List<Map<String, Object>> rows, Map<String, Object> where) {
+        Object existing = rows.get(0).get(Constants.PLAN_ID);
+        if (!(existing instanceof Set)) {
+            log.warn("processContentLookupRemoval: Invalid planid data type - contentId={}", contentId);
+            return Constants.RESULT_SKIPPED;
+        }
+        Set<String> planIds = new HashSet<>((Set<String>) existing);
+        if (planIds.size() == 1 && planIds.contains(cbPlanId)) {
+            deleteContentLookupRow(contentId, cbPlanId, where);
+            return Constants.RESULT_DELETED;
+        } else if (planIds.size() > 1 && planIds.contains(cbPlanId)) {
+            updateContentLookupRow(contentId, cbPlanId, planIds, where);
+            return Constants.RESULT_UPDATED;
+        }
+        return Constants.RESULT_SKIPPED;
+    }
+
+    /**
+     * Deletes content lookup row.
+     *
+     * @param contentId content ID
+     * @param cbPlanId  CB Plan ID
+     * @param where     query criteria
+     */
+    private void deleteContentLookupRow(String contentId, String cbPlanId, Map<String, Object> where) {
+        cassandraOperation.deleteRecord(Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3_CONTENT_LOOKUP, where);
+        log.info("deleteContentLookupRow: Deleted row - contentId={}, lastPlanId={}",
+                contentId, cbPlanId);
+    }
+
+    /**
+     * Updates content lookup row by removing a plan from the set.
+     *
+     * @param contentId content ID
+     * @param cbPlanId  CB Plan ID to remove
+     * @param planIds   current set of plan IDs
+     * @param where     query criteria
+     */
+    private void updateContentLookupRow(String contentId, String cbPlanId, Set<String> planIds,
+                                        Map<String, Object> where) {
+        planIds.remove(cbPlanId);
+        Map<String, Object> update = Map.of(Constants.PLAN_ID_COLUMN, planIds);
+        cassandraOperation.updateRecord(Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3_CONTENT_LOOKUP, update, where);
+        log.info("updateContentLookupRow: Removed plan - contentId={}, removedPlanId={}, remainingCount={}",
+                contentId, cbPlanId, planIds.size());
+    }
+
+    /**
+     * Gets content metadata from Redis cache first, falls back to extended content read API if not cached.
+     * Uses the same Redis key format as the extended content read API in knowledge-platform.
+     * Redis key: extended_read_content_{contentId}
+     * API endpoint: GET /content/v1/extended/read/{contentId}
+     *
+     * @param contentId content ID
+     * @return content metadata map, or empty map if not found
+     * @throws JsonProcessingException if deserialization fails
+     */
+    public Map<String, Object> getContentMetadata(String contentId) throws JsonProcessingException {
+        String cacheKey = Constants.EXTENDED_READ_CONTENT_CACHE_KEY_PREFIX + contentId;
+        String cachedContent = redisCacheMgr.getFromCache(cacheKey);
+        if (StringUtils.isNotBlank(cachedContent)) {
+            log.debug("getContentMetadata: Redis cache hit - contentId={}, cacheKey={}", contentId, cacheKey);
+            return mapper.readValue(cachedContent, new TypeReference<Map<String, Object>>() {
+            });
+        }
+        log.debug("getContentMetadata: Redis cache miss, calling extended content read API - contentId={}, cacheKey={}",
+                contentId, cacheKey);
+        Map<String, Object> contentDetails = readExtendedContent(contentId);
+        return Objects.nonNull(contentDetails) ? contentDetails : new HashMap<>();
+    }
+
+    /**
+     * Reads content metadata from extended content read API in knowledge-platform.
+     * Endpoint: GET /content/v1/extended/read/{contentId}
+     * Special handling: External content (contentId starts with "ext_") uses readExternalContent.
+     *
+     * @param contentId content identifier
+     * @return content metadata map, or empty map if not found
+     */
+    private Map<String, Object> readExtendedContent(String contentId) {
+        if (StringUtils.isBlank(contentId)) {
+            log.error("Content ID is null or empty for extended read");
+            return Collections.emptyMap();
+        }
+        try {
+            log.info("Reading extended content for contentId: {}", contentId);
+            if (contentId.startsWith(Constants.EXTERNAL_CONTENT_PREFIX)) {
+                return readExternalContent(contentId);
+            }
+            return callExtendedContentReadAPI(contentId);
+        } catch (Exception e) {
+            log.error("Failed to read extended content for contentId: {}", contentId, e);
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Calls extended content read API endpoint.
+     *
+     * @param contentId content identifier
+     * @return content metadata map, or empty map if not found
+     */
+    private Map<String, Object> callExtendedContentReadAPI(String contentId) {
+        String url = buildExtendedContentURL(contentId);
+        Map<String, Object> response = (Map<String, Object>) outboundRequestHandlerService.fetchResult(url);
+        if (Objects.nonNull(response) && Constants.OK.equalsIgnoreCase((String) response.get(Constants.RESPONSE_CODE))) {
+            Map<String, Object> result = (Map<String, Object>) response.get(Constants.RESULT);
+            return (Map<String, Object>) result.get(Constants.CONTENT);
+        }
+        log.warn("Extended content read returned non-OK response for contentId: {}", contentId);
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Builds URL for extended content read API.
+     *
+     * @param contentId content identifier
+     * @return API URL
+     */
+    private String buildExtendedContentURL(String contentId) {
+        return propertiesCache.getProperty(Constants.CONTENT_SERVICE_HOST) +
+                propertiesCache.getProperty(Constants.EXTENDED_CONTENT_READ_END_POINT) +
+                "/" + contentId;
+    }
+
+    /**
+     * Reads external content information from the external content service.
+     *
+     * @param contentId external content ID (starts with "ext_")
+     * @return content metadata map, or empty map if not found
+     */
+    private Map<String, Object> readExternalContent(String contentId) {
+        try {
+            log.info("Reading external content for contentId: {}", contentId);
+            String url = buildExternalContentURL(contentId);
+            return fetchExternalContentFromAPI(url);
+        } catch (Exception e) {
+            log.error("Failed to read external content for contentId: {}", contentId, e);
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Fetches external content from API and extracts event data.
+     *
+     * @param url API URL
+     * @return event data map, or empty map if not found
+     */
+    private Map<String, Object> fetchExternalContentFromAPI(String url) {
+        Map<String, Object> response = (Map<String, Object>) outboundRequestHandlerService.fetchResult(url);
+        if (Objects.nonNull(response) && response.containsKey(Constants.RESULT)) {
+            Map<String, Object> result = (Map<String, Object>) response.get(Constants.RESULT);
+            Map<String, Object> event = (Map<String, Object>) result.get(Constants.EVENT);
+            if (Objects.nonNull(event) && !event.isEmpty()) {
+                return event;
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Builds URL for external content read API.
+     *
+     * @param contentId content identifier
+     * @return API URL
+     */
+    private String buildExternalContentURL(String contentId) {
+        return propertiesCache.getProperty(Constants.CB_PORES_SERVICE_HOST) +
+                propertiesCache.getProperty(Constants.EXTERNAL_CONTENT_READ_END_POINT) +
+                "/" + contentId;
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanDataTransformServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanDataTransformServiceV3Impl.java
@@ -1,0 +1,257 @@
+package com.igot.cb.cbplan.service.impl;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import com.datastax.oss.driver.api.core.uuid.Uuids;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.CbExtServerProperties;
+import com.igot.cb.util.Constants;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service for CB Plan data transformation operations.
+ *
+ * @version 3.0
+ */
+@Service
+@Slf4j
+public class CbPlanDataTransformServiceV3Impl {
+    private final CbExtServerProperties serverProperties;
+    private final ObjectMapper mapper;
+
+    public CbPlanDataTransformServiceV3Impl(CbExtServerProperties serverProperties) {
+        this.serverProperties = serverProperties;
+        this.mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    /**
+     * Prepares CB Plan data for insert (CREATE operation).
+     *
+     * @param request API request
+     * @param userId  user ID
+     * @return prepared CB Plan map
+     * @throws JsonProcessingException if JSON processing fails
+     */
+    public Map<String, Object> prepareCbPlanForInsert(ApiRequest request, String userId)
+            throws JsonProcessingException {
+        Map<String, Object> requestMap = (Map<String, Object>) request.getRequest();
+        Map<String, Object> cbPlan = new HashMap<>();
+        cbPlan.put(Constants.PLAN_ID, String.valueOf(Uuids.timeBased()));
+        cbPlan.put(Constants.CREATED_BY, userId);
+        cbPlan.put(Constants.CREATED_AT, Instant.now());
+        cbPlan.put(Constants.STATUS, Constants.DRAFT);
+        populatePlanFields(cbPlan, requestMap);
+        return cbPlan;
+    }
+
+    /**
+     * Prepares CB Plan data for update (UPDATE operation on DRAFT).
+     *
+     * @param incomingRequest incoming request map
+     * @param userId          user ID
+     * @return prepared update map
+     * @throws JsonProcessingException if JSON processing fails
+     */
+    public Map<String, Object> prepareCbPlanForUpdate(Map<String, Object> incomingRequest, String userId)
+            throws JsonProcessingException {
+        Map<String, Object> updatedRequest = new HashMap<>();
+        updatedRequest.put(Constants.UPDATED_BY, userId);
+        updatedRequest.put(Constants.UPDATED_AT, Instant.now());
+        populateUpdateFields(updatedRequest, incomingRequest);
+        return updatedRequest;
+    }
+
+    /**
+     * Prepares basic publish update data.
+     *
+     * @param incomingRequest incoming request map
+     * @param userId          user ID
+     * @return prepared publish update map
+     */
+    public Map<String, Object> prepareBasicPublishUpdate(Map<String, Object> incomingRequest, String userId) {
+        String comment = (String) incomingRequest.get(Constants.COMMENT);
+        Map<String, Object> updatedRequest = new HashMap<>();
+        updatedRequest.put(Constants.PUBLISHED_AT, Instant.now());
+        updatedRequest.put(Constants.PUBLISHED_BY, userId);
+        updatedRequest.put(Constants.UPDATED_AT, Instant.now());
+        updatedRequest.put(Constants.COMMENT, comment);
+        updatedRequest.put(Constants.UPDATED_BY, userId);
+        return updatedRequest;
+    }
+
+    /**
+     * Prepares CB Plan for re-publish (when updating a LIVE plan).
+     * <p>
+     * <p>
+     * /**
+     * Builds updated plan data for LIVE plan modifications.
+     *
+     * @param incomingRequest         incoming request map
+     * @param existingCbPlan          existing CB Plan data
+     * @param userId                  user ID
+     * @param rootOrgIdsInContextData org IDs extracted from context
+     * @param response                API response object
+     * @return built update map or empty map if validation fails
+     */
+    public Map<String, Object> buildUpdatedPlanForLive(Map<String, Object> incomingRequest,
+                                                       Map<String, Object> existingCbPlan,
+                                                       String userId, Set<String> rootOrgIdsInContextData,
+                                                       ApiResponse response) {
+        List<String> allowedFields = serverProperties.getCbPlanUpdateAllowedFields();
+        Map<String, Object> updatedCbPlan = new HashMap<>();
+        for (String field : allowedFields) {
+            if (incomingRequest.containsKey(field)
+                    && !processLivePlanField(field, incomingRequest, existingCbPlan, updatedCbPlan, response)) {
+                return Collections.emptyMap();
+            }
+        }
+        updatedCbPlan.put(Constants.UPDATED_AT, Instant.now());
+        updatedCbPlan.put(Constants.UPDATED_BY, userId);
+        updatedCbPlan.put(Constants.ROOT_ORG_IDS_IN_CONTEXT_DATA, new ArrayList<>(rootOrgIdsInContextData));
+        return updatedCbPlan;
+    }
+
+    /**
+     * Prepares archive update data.
+     *
+     * @param comment archive comment
+     * @param userId  user ID
+     * @return prepared archive update map
+     */
+    public Map<String, Object> prepareArchiveUpdate(String comment, String userId) {
+        Map<String, Object> updateData = new HashMap<>();
+        updateData.put(Constants.STATUS, Constants.CB_RETIRE);
+        updateData.put(Constants.UPDATED_BY, userId);
+        updateData.put(Constants.UPDATED_AT, Instant.now());
+        if (Objects.nonNull(comment)) {
+            updateData.put(Constants.COMMENT, comment);
+        }
+        return updateData;
+    }
+
+    /**
+     * Parses end date from various formats.
+     *
+     * @param endDateObj end date object
+     * @return parsed Instant or null
+     */
+    public Instant parseEndDate(Object endDateObj) {
+        if (Objects.isNull(endDateObj)) {
+            return null;
+        }
+        try {
+            if (endDateObj instanceof Date date) {
+                return date.toInstant();
+            }
+            if (endDateObj instanceof Instant instant) {
+                return instant;
+            }
+            if (endDateObj instanceof Long longValue) {
+                return Instant.ofEpochMilli(longValue);
+            }
+            if (endDateObj instanceof String stringValue) {
+                return parseEndDateFromString(stringValue);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(Constants.ERR_INVALID_END_DATE_FORMAT + endDateObj, e);
+        }
+        return null;
+    }
+
+    private void populatePlanFields(Map<String, Object> cbPlan, Map<String, Object> requestMap)
+            throws JsonProcessingException {
+        cbPlan.put(Constants.IS_APAR, requestMap.getOrDefault(Constants.IS_APAR, false));
+        cbPlan.put(Constants.ORG_ID_LIST, requestMap.get(Constants.ORG_ID_LIST));
+        cbPlan.put(Constants.ORG_SCOPE, requestMap.get(Constants.ORG_SCOPE));
+        cbPlan.put(Constants.CONTENT_LIST, requestMap.get(Constants.CONTENT_LIST));
+        cbPlan.put(Constants.NAME, requestMap.get(Constants.NAME));
+        cbPlan.put(Constants.COMMENT, requestMap.get(Constants.COMMENT));
+        cbPlan.put(Constants.CONTENT_TYPE, requestMap.get(Constants.CONTENT_TYPE));
+        cbPlan.put(Constants.END_DATE_REQUEST, parseEndDate(requestMap.get(Constants.END_DATE_REQUEST)));
+        cbPlan.put(Constants.CONTEXT_DATA_REQUEST, mapper.writeValueAsString(requestMap.get(Constants.CONTEXT_DATA_REQUEST)));
+        cbPlan.put(Constants.PLAN_YEAR, requestMap.get(Constants.PLAN_YEAR));
+        if (requestMap.containsKey(Constants.PLAN_TYPE)) {
+            cbPlan.put(Constants.PLAN_TYPE, requestMap.get(Constants.PLAN_TYPE));
+        }
+    }
+
+    private void populateUpdateFields(Map<String, Object> updatedRequest, Map<String, Object> incomingRequest)
+            throws JsonProcessingException {
+        updatedRequest.put(Constants.IS_APAR, incomingRequest.getOrDefault(Constants.IS_APAR, false));
+        updatedRequest.put(Constants.ORG_ID_LIST, incomingRequest.get(Constants.ORG_ID_LIST));
+        updatedRequest.put(Constants.ORG_SCOPE, incomingRequest.get(Constants.ORG_SCOPE));
+        updatedRequest.put(Constants.CONTENT_LIST, incomingRequest.get(Constants.CONTENT_LIST));
+        updatedRequest.put(Constants.NAME, incomingRequest.get(Constants.NAME));
+        updatedRequest.put(Constants.COMMENT, incomingRequest.get(Constants.COMMENT));
+        updatedRequest.put(Constants.CONTENT_TYPE, incomingRequest.get(Constants.CONTENT_TYPE));
+        updatedRequest.put(Constants.END_DATE_REQUEST, parseEndDate(incomingRequest.get(Constants.END_DATE_REQUEST)));
+        updatedRequest.put(Constants.CONTEXT_DATA_REQUEST,
+                mapper.writeValueAsString(incomingRequest.get(Constants.CONTEXT_DATA_REQUEST)));
+        updatedRequest.put(Constants.PLAN_YEAR, incomingRequest.get(Constants.PLAN_YEAR));
+        if (incomingRequest.containsKey(Constants.PLAN_TYPE)) {
+            updatedRequest.put(Constants.PLAN_TYPE, incomingRequest.get(Constants.PLAN_TYPE));
+        }
+    }
+
+    private boolean processLivePlanField(String field, Map<String, Object> incomingRequest,
+                                         Map<String, Object> existingCbPlan, Map<String, Object> updatedCbPlan,
+                                         ApiResponse response) {
+        if (Constants.IS_APAR.equalsIgnoreCase(field)) {
+            return validateIsAparUpdate(incomingRequest, existingCbPlan, field, updatedCbPlan, response);
+        }
+        Object value = incomingRequest.get(field);
+        if (Objects.nonNull(value)) {
+            updatedCbPlan.put(field, value);
+            return true;
+        } else {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(String.format(Constants.ERR_FIELD_CANNOT_BE_NULL, field));
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return false;
+        }
+    }
+
+    private boolean validateIsAparUpdate(Map<String, Object> incomingRequest, Map<String, Object> existingCbPlan,
+                                         String field, Map<String, Object> updatedCbPlan, ApiResponse response) {
+        boolean existingIsApar = Objects.nonNull(existingCbPlan.get(Constants.IS_APAR))
+                && (Boolean) existingCbPlan.get(Constants.IS_APAR);
+        if (existingIsApar) {
+            boolean newIsApar = Objects.nonNull(incomingRequest.get(field))
+                    && (Boolean) incomingRequest.get(field);
+            if (!newIsApar) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr(Constants.ERR_CANNOT_CHANGE_ISAPAR);
+                response.setResponseCode(HttpStatus.BAD_REQUEST);
+                return false;
+            }
+        }
+        updatedCbPlan.put(field, incomingRequest.get(field));
+        return true;
+    }
+
+    private Instant parseEndDateFromString(String endDateStr) {
+        try {
+            return Instant.parse(endDateStr);
+        } catch (DateTimeParseException e) {
+            LocalDate localDate = LocalDate.parse(endDateStr, DateTimeFormatter.ofPattern(Constants.DATE_FORMAT_YYYY_MM_DD));
+            ZoneId kolkata = ZoneId.of(Constants.TIMEZONE_ASIA_KOLKATA);
+            return localDate.atTime(23, 59, 59).atZone(kolkata).toInstant();
+        }
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanElasticSearchServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanElasticSearchServiceV3Impl.java
@@ -1,0 +1,102 @@
+package com.igot.cb.cbplan.service.impl;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.igot.cb.elasticsearch.service.EsUtilService;
+import com.igot.cb.util.CbExtServerProperties;
+import com.igot.cb.util.Constants;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service for managing CB Plan ElasticSearch operations.
+ *
+ * @version 3.0
+ */
+@Service
+@Slf4j
+public class CbPlanElasticSearchServiceV3Impl {
+    private final EsUtilService esUtilService;
+    private final CbExtServerProperties serverProperties;
+
+    public CbPlanElasticSearchServiceV3Impl(EsUtilService esUtilService, CbExtServerProperties serverProperties) {
+        this.esUtilService = esUtilService;
+        this.serverProperties = serverProperties;
+    }
+
+    /**
+     * Indexes CB Plan to ElasticSearch.
+     *
+     * @param planId   CB Plan ID
+     * @param planData CB Plan data to index
+     */
+    public void indexToElasticSearch(String planId, Map<String, Object> planData) {
+        planData.put(Constants.ID, planId);
+        Map<String, Object> sanitizedMap = sanitizeForElastic(planData);
+        esUtilService.addDocument(
+                serverProperties.getCpPlanIndex(),
+                Constants.INDEX_TYPE,
+                planId,
+                sanitizedMap,
+                serverProperties.getElasticCbPlanJsonPath());
+    }
+
+    /**
+     * Updates ElasticSearch for a modified CB Plan.
+     *
+     * @param cbPlanId       CB Plan ID
+     * @param updatedRequest updated request data
+     */
+    public void updateElasticSearchForPlan(String cbPlanId, Map<String, Object> updatedRequest) {
+        Map<String, Object> sanitizedMap = sanitizeForElastic(updatedRequest);
+        esUtilService.updateDocument(serverProperties.getCpPlanIndex(), Constants.INDEX_TYPE,
+                cbPlanId, sanitizedMap, serverProperties.getElasticCbPlanJsonPath());
+    }
+
+    /**
+     * Updates ElasticSearch when archiving a CB Plan.
+     *
+     * @param cbPlanId       CB Plan ID
+     * @param existingCbPlan existing CB Plan data
+     * @param updateData     update data (comment, updatedBy, updatedAt)
+     */
+    public void updateElasticSearchForArchive(String cbPlanId, Map<String, Object> existingCbPlan,
+                                              Map<String, Object> updateData) {
+        Map<String, Object> esDocument = new HashMap<>(existingCbPlan);
+        esDocument.putAll(updateData);
+        esDocument.put(Constants.ID, cbPlanId);
+        esDocument.put(Constants.STATUS, Constants.CB_RETIRE);
+        Map<String, Object> sanitizedMap = sanitizeForElastic(esDocument);
+        esUtilService.addDocument(
+                serverProperties.getCpPlanIndex(),
+                Constants.INDEX_TYPE,
+                cbPlanId,
+                sanitizedMap,
+                serverProperties.getElasticCbPlanJsonPath());
+    }
+
+    /**
+     * Sanitizes CB Plan data for ElasticSearch indexing.
+     * Converts Instant objects to ISO string format.
+     *
+     * @param input raw plan data
+     * @return sanitized data ready for ES indexing
+     */
+    public Map<String, Object> sanitizeForElastic(Map<String, Object> input) {
+        Map<String, Object> sanitized = new HashMap<>();
+        for (Map.Entry<String, Object> entry : input.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof Instant instant) {
+                sanitized.put(entry.getKey(), DateTimeFormatter.ISO_INSTANT.format(instant));
+            } else {
+                sanitized.put(entry.getKey(), value);
+            }
+        }
+        return sanitized;
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanEnrichmentServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanEnrichmentServiceV3Impl.java
@@ -1,0 +1,92 @@
+package com.igot.cb.cbplan.service.impl;
+
+import java.util.*;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import com.igot.cb.service.ContentInfoServiceImpl;
+import com.igot.cb.service.UserAndOrgServiceImpl;
+import com.igot.cb.util.Constants;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service for enriching CB Plan search results.
+ *
+ * @version 3.0
+ */
+@Service
+@Slf4j
+public class CbPlanEnrichmentServiceV3Impl {
+    private final UserAndOrgServiceImpl userAndOrgService;
+    private final ContentInfoServiceImpl contentService;
+
+    public CbPlanEnrichmentServiceV3Impl(UserAndOrgServiceImpl userAndOrgService, ContentInfoServiceImpl contentService) {
+        this.userAndOrgService = userAndOrgService;
+        this.contentService = contentService;
+    }
+
+    /**
+     * Enriches search results with user and content information.
+     *
+     * @param dataNode search results data
+     * @return enriched search results
+     */
+    public List<Map<String, Object>> enrichSearchResults(List<Map<String, Object>> dataNode) {
+        List<Map<String, Object>> enrichedData = new ArrayList<>();
+        for (Map<String, Object> item : dataNode) {
+            Map<String, Object> enrichedItem = new HashMap<>(item);
+            enrichCreatedByInfo(item, enrichedItem);
+            enrichContentListInfo(item, enrichedItem);
+            enrichedData.add(enrichedItem);
+        }
+        return enrichedData;
+    }
+
+    /**
+     * Enriches createdBy information with user details.
+     *
+     * @param item         original item
+     * @param enrichedItem enriched item to populate
+     */
+    public void enrichCreatedByInfo(Map<String, Object> item, Map<String, Object> enrichedItem) {
+        if (!item.containsKey(Constants.CREATED_BY)) {
+            return;
+        }
+        Object createdByObj = item.get(Constants.CREATED_BY);
+        if (Objects.isNull(createdByObj)) {
+            return;
+        }
+        if (createdByObj instanceof String stringValue && StringUtils.isNotBlank(stringValue)) {
+            Map<String, Object> userInfoMap = userAndOrgService.readUserProfile(
+                    stringValue,
+                    Arrays.asList(Constants.FIRSTNAME, Constants.USER_ID));
+            if (MapUtils.isNotEmpty(userInfoMap)) {
+                enrichedItem.put(Constants.CREATED_BY_NAME, userInfoMap.get(Constants.FIRSTNAME));
+                enrichedItem.put(Constants.CREATED_BY, item.get(Constants.CREATED_BY));
+            }
+        }
+    }
+
+    /**
+     * Enriches contentList with content metadata.
+     *
+     * @param item         original item
+     * @param enrichedItem enriched item to populate
+     */
+    public void enrichContentListInfo(Map<String, Object> item, Map<String, Object> enrichedItem) {
+        if (!item.containsKey(Constants.CONTENT_LIST)) {
+            return;
+        }
+        Object contentListObj = item.get(Constants.CONTENT_LIST);
+        if (Objects.isNull(contentListObj)) {
+            return;
+        }
+        if (contentListObj instanceof List) {
+            enrichedItem.put(Constants.CONTENT_LIST,
+                    contentService.enrichContentInfoForCBPlan((List<String>) contentListObj));
+        }
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanOrgLookupServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanOrgLookupServiceV3Impl.java
@@ -1,0 +1,245 @@
+package com.igot.cb.cbplan.service.impl;
+
+import java.time.Instant;
+import java.util.*;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.Constants;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service for managing CB Plan organization lookup table operations.
+ *
+ * @version 3.0
+ */
+@Service
+@Slf4j
+public class CbPlanOrgLookupServiceV3Impl {
+    private final CassandraOperation cassandraOperation;
+    private final ObjectMapper mapper;
+
+    public CbPlanOrgLookupServiceV3Impl(CassandraOperation cassandraOperation) {
+        this.cassandraOperation = cassandraOperation;
+        this.mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    /**
+     * Handles organization lookup changes when updating a CB Plan.
+     *
+     * @param cbPlanId           CB Plan ID
+     * @param planYear           plan year (e.g., "2026-27")
+     * @param existingRootOrgIds existing organization IDs
+     * @param newRootOrgIds      new organization IDs
+     * @param existingOrgScope   existing organization scope
+     * @param response           API response object
+     */
+    public void handleOrgLookupChanges(String cbPlanId, String planYear, Set<String> existingRootOrgIds,
+                                       Set<String> newRootOrgIds, String existingOrgScope,
+                                       ApiResponse response) {
+        if (CollectionUtils.isEmpty(existingRootOrgIds) || CollectionUtils.isEmpty(newRootOrgIds)) {
+            return;
+        }
+        Set<String> removed = new HashSet<>(existingRootOrgIds);
+        removed.removeAll(newRootOrgIds);
+        if (CollectionUtils.isNotEmpty(removed) && (Constants.CUSTOM.equalsIgnoreCase(existingOrgScope)
+                || Constants.SINGLE.equalsIgnoreCase(existingOrgScope))) {
+            ApiResponse removeResp = upsertCustomOrgLookup(cbPlanId, planYear, removed, null, false);
+            if (!Constants.SUCCESS.equals(removeResp.get(Constants.RESPONSE))) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr(removeResp.getParams().getErr());
+                response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+                return;
+            }
+        }
+        if (Constants.ALL.equalsIgnoreCase(existingOrgScope)) {
+            Set<String> newlyAdded = new HashSet<>(newRootOrgIds);
+            newlyAdded.removeAll(existingRootOrgIds);
+            if (CollectionUtils.isNotEmpty(newlyAdded)) {
+                ApiResponse removeResp = upsertAllOrgLookup(cbPlanId, planYear, null, false);
+                if (!Constants.SUCCESS.equals(removeResp.get(Constants.RESPONSE))) {
+                    response.getParams().setStatus(Constants.FAILED);
+                    response.getParams().setErr(removeResp.getParams().getErr());
+                    response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        }
+    }
+
+    /**
+     * Upserts custom organization lookup entries.
+     *
+     * @param cbPlanId  CB Plan ID
+     * @param planYear  plan year
+     * @param orgIdList list of organization IDs
+     * @param endDate   end date (can be null)
+     * @param isActive  active status
+     * @return API response
+     */
+    public ApiResponse upsertCustomOrgLookup(String cbPlanId, String planYear, Set<String> orgIdList,
+                                             Instant endDate, boolean isActive) {
+        ApiResponse response = new ApiResponse();
+        try {
+            if (CollectionUtils.isEmpty(orgIdList)) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr("orgIdList is empty. Cannot create lookup entries.");
+                return response;
+            }
+            List<Map<String, Object>> lookupMaps = new ArrayList<>();
+            for (String orgId : orgIdList) {
+                Map<String, Object> lookupMap = new HashMap<>();
+                lookupMap.put("planyear", planYear);
+                lookupMap.put("planid", cbPlanId);
+                lookupMap.put("orgid", orgId);
+                if (Objects.nonNull(endDate)) {
+                    lookupMap.put("enddate", endDate);
+                }
+                lookupMap.put("isactive", isActive);
+                lookupMaps.add(lookupMap);
+            }
+            response = cassandraOperation.insertBulkRecord(
+                    Constants.KEYSPACE_SUNBIRD,
+                    Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ORG,
+                    lookupMaps);
+            if (!Constants.SUCCESS.equals(response.getParams().getStatus())) {
+                return response;
+            }
+            response.getParams().setStatus(Constants.SUCCESS);
+            response.getResult().put("message", "Lookup entries created successfully for all orgIds");
+        } catch (Exception e) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr("Exception while creating org lookup entries: " + e.getMessage());
+            log.error("CbPlanOrgLookupService.upsertCustomOrgLookup: Error inserting org lookup entries for CB Plan: {}",
+                    cbPlanId, e);
+        }
+        return response;
+    }
+
+    /**
+     * Upserts ALL organization lookup entry.
+     *
+     * @param cbPlanId CB Plan ID
+     * @param planYear plan year
+     * @param endDate  end date (can be null)
+     * @param isActive active status
+     * @return API response
+     */
+    public ApiResponse upsertAllOrgLookup(String cbPlanId, String planYear, Instant endDate, boolean isActive) {
+        ApiResponse response = new ApiResponse();
+        try {
+            Map<String, Object> allOrgMap = new HashMap<>();
+            allOrgMap.put("planyear", planYear);
+            allOrgMap.put(Constants.PLAN_ID, cbPlanId);
+            if (Objects.nonNull(endDate)) {
+                allOrgMap.put(Constants.END_DATE, endDate);
+            }
+            allOrgMap.put("isactive", isActive);
+            response = (ApiResponse) cassandraOperation.insertRecord(
+                    Constants.KEYSPACE_SUNBIRD,
+                    Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ALL_ORG,
+                    allOrgMap);
+        } catch (Exception e) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.put(Constants.RESPONSE, Constants.FAILED);
+            response.getParams().setErr("Exception while inserting ALL org lookup: " + e.getMessage());
+            log.error("CbPlanOrgLookupService.upsertAllOrgLookup: Error inserting ALL org lookup for CB Plan: {}",
+                    cbPlanId, e);
+        }
+        return response;
+    }
+
+    /**
+     * Deactivates organization lookup entries for archived CB Plans.
+     *
+     * @param cbPlanId       CB Plan ID
+     * @param planYear       plan year
+     * @param existingCbPlan existing CB Plan data
+     * @param response       API response object
+     */
+    public void deactivateOrgLookupEntries(String cbPlanId, String planYear, Map<String, Object> existingCbPlan,
+                                           ApiResponse response) {
+        String orgScope = (String) existingCbPlan.get(Constants.ORG_SCOPE);
+        Set<String> rootOrgIds = extractUniqueRootOrgIds(existingCbPlan);
+        ApiResponse lookupResp = null;
+        if (Constants.SINGLE.equalsIgnoreCase(orgScope) || Constants.CUSTOM.equalsIgnoreCase(orgScope)) {
+            lookupResp = upsertCustomOrgLookup(cbPlanId, planYear, rootOrgIds, null, false);
+        } else if (Constants.ALL.equalsIgnoreCase(orgScope)) {
+            lookupResp = upsertAllOrgLookup(cbPlanId, planYear, null, false);
+        }
+        if (Objects.nonNull(lookupResp) && !Constants.SUCCESS.equals(lookupResp.get(Constants.RESPONSE))) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(lookupResp.getParams().getErr());
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Extracts unique root organization IDs from contextData.
+     *
+     * @param rawRequest raw request map containing contextData
+     * @return set of unique root organization IDs
+     */
+    public Set<String> extractUniqueRootOrgIds(Map<String, Object> rawRequest) {
+        Set<String> orgIdSet = new HashSet<>();
+        Object contextDataObj = rawRequest.get(Constants.CONTEXT_DATA_REQUEST);
+        if (Objects.isNull(contextDataObj)) {
+            return orgIdSet;
+        }
+        Map<String, Object> contextData = new HashMap<>();
+        try {
+            if (contextDataObj instanceof String stringData) {
+                contextData = mapper.readValue(stringData, new TypeReference<Map<String, Object>>() {
+                });
+            } else if (contextDataObj instanceof Map) {
+                contextData = (Map<String, Object>) contextDataObj;
+            } else {
+                return orgIdSet;
+            }
+        } catch (Exception e) {
+            log.warn("CbPlanOrgLookupService.extractUniqueRootOrgIds: Failed to parse contextData", e);
+            return orgIdSet;
+        }
+        Map<String, Object> accessControl = (Map<String, Object>) contextData.getOrDefault(
+                Constants.ACCESS_CONTROL, new HashMap<>());
+        List<Map<String, Object>> userGroups = (List<Map<String, Object>>) accessControl.getOrDefault(
+                Constants.USER_GROUPS, new ArrayList<>());
+        for (Map<String, Object> userGroup : userGroups) {
+            List<Map<String, Object>> criteriaList = (List<Map<String, Object>>) userGroup.get(
+                    Constants.USER_GROUP_CRITERIA_LIST);
+            if (CollectionUtils.isNotEmpty(criteriaList)) {
+                extractOrgIdsFromCriteria(criteriaList, orgIdSet);
+            }
+        }
+        return orgIdSet;
+    }
+
+    /**
+     * Extracts organization IDs from criteria list.
+     *
+     * @param criteriaList list of criteria maps
+     * @param orgIdSet     set to populate with extracted org IDs
+     */
+    public void extractOrgIdsFromCriteria(List<Map<String, Object>> criteriaList, Set<String> orgIdSet) {
+        for (Map<String, Object> criteria : criteriaList) {
+            String criteriaKey = (String) criteria.get(Constants.CRITERIA_KEY);
+            if (Constants.ROOT_ORG_ID.equalsIgnoreCase(criteriaKey)
+                    || Constants.TARGETED_ORGANISATION.equalsIgnoreCase(criteriaKey)) {
+                List<String> values = (List<String>) criteria.get(Constants.CRITERIA_VALUE);
+                if (CollectionUtils.isNotEmpty(values)) {
+                    orgIdSet.addAll(values);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanServiceV3Impl.java
@@ -1,0 +1,1519 @@
+package com.igot.cb.cbplan.service.impl;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.igot.cb.model.CbPlanDto;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.igot.cb.cache.CbPlanCacheMgrV3;
+import com.igot.cb.cache.RedisCacheMgr;
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.cbplan.dto.CbPlanContentOccurrence;
+import com.igot.cb.cbplan.dto.CbPlanDictionaryCacheEntry;
+import com.igot.cb.cbplan.dto.CbPlanReadResponseDto;
+import com.igot.cb.cbplan.util.CbPlanYearUtil;
+import com.igot.cb.elasticsearch.dto.SearchCriteria;
+import com.igot.cb.elasticsearch.dto.SearchResult;
+import com.igot.cb.elasticsearch.service.EsUtilService;
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.model.ApiRespParam;
+import com.igot.cb.cbplan.service.CbPlanServiceV3;
+import com.igot.cb.service.ContentInfoServiceImpl;
+import com.igot.cb.service.OutboundRequestHandlerServiceImpl;
+import com.igot.cb.service.UserAndOrgServiceImpl;
+import com.igot.cb.util.AccessTokenValidator;
+import com.igot.cb.util.CbExtServerProperties;
+import com.igot.cb.util.Constants;
+import com.igot.cb.util.ProjectUtil;
+import com.igot.cb.util.RequestValidator;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service implementation for CB Plan V3 operations.
+ *
+ * @version 3.0
+ */
+@Service
+@Slf4j
+public class CbPlanServiceV3Impl implements CbPlanServiceV3 {
+    private final AccessTokenValidator accessTokenValidator;
+    private final CassandraOperation cassandraOperation;
+    private final CbExtServerProperties serverProperties;
+    private final EsUtilService esUtilService;
+    private final RequestValidator requestValidator;
+    private final ContentInfoServiceImpl contentService;
+    private final ObjectMapper mapper;
+    private final CbPlanValidationServiceV3Impl validationService;
+    private final CbPlanDataTransformServiceV3Impl dataTransformService;
+    private final CbPlanOrgLookupServiceV3Impl orgLookupService;
+    private final CbPlanContentLookupServiceV3Impl contentLookupService;
+    private final CbPlanElasticSearchServiceV3Impl elasticSearchService;
+    private final CbPlanEnrichmentServiceV3Impl enrichmentService;
+    private final CbPlanCacheMgrV3 cbPlanCacheMgrV3;
+    private final RedisCacheMgr redisCacheMgr;
+
+    public CbPlanServiceV3Impl(AccessTokenValidator accessTokenValidator,
+                               CassandraOperation cassandraOperation,
+                               CbExtServerProperties serverProperties,
+                               UserAndOrgServiceImpl userAndOrgService,
+                               EsUtilService esUtilService,
+                               RequestValidator requestValidator,
+                               ContentInfoServiceImpl contentService,
+                               OutboundRequestHandlerServiceImpl outboundRequestHandlerService,
+                               CbPlanCacheMgrV3 cbPlanCacheMgrV3,
+                               RedisCacheMgr redisCacheMgr) {
+        this.orgLookupService = new CbPlanOrgLookupServiceV3Impl(cassandraOperation);
+        this.contentLookupService = new CbPlanContentLookupServiceV3Impl(cassandraOperation, redisCacheMgr, outboundRequestHandlerService);
+        this.elasticSearchService = new CbPlanElasticSearchServiceV3Impl(esUtilService, serverProperties);
+        this.enrichmentService = new CbPlanEnrichmentServiceV3Impl(userAndOrgService, contentService);
+        this.validationService = new CbPlanValidationServiceV3Impl(accessTokenValidator, userAndOrgService, requestValidator);
+        this.dataTransformService = new CbPlanDataTransformServiceV3Impl(serverProperties);
+        this.accessTokenValidator = accessTokenValidator;
+        this.cassandraOperation = cassandraOperation;
+        this.serverProperties = serverProperties;
+        this.esUtilService = esUtilService;
+        this.requestValidator = requestValidator;
+        this.contentService = contentService;
+        this.cbPlanCacheMgrV3 = cbPlanCacheMgrV3;
+        this.redisCacheMgr = redisCacheMgr;
+        this.mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Override
+    public ApiResponse createCbPlan(ApiRequest request, String userOrgId, String authToken) {
+        log.info("CbPlanServiceV3Impl.createCbPlan: Creating CB Plan for orgId: {}", userOrgId);
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_CB_PLAN_CREATE);
+        try {
+            String userId = validationService.validateAndExtractUserId(authToken, response);
+            if (StringUtils.isEmpty(userId)) {
+                return response;
+            }
+            String rootOrgId = validationService.validateUserOrganization(userId, response);
+            if (StringUtils.isEmpty(rootOrgId)) {
+                return response;
+            }
+            boolean isCCA = validationService.validateOrgCCA(rootOrgId, response);
+            if (Constants.FAILED.equalsIgnoreCase(response.getParams().getStatus())) {
+                return response;
+            }
+            if (!validationService.validateRequest(request, isCCA, userOrgId, response)) {
+                return response;
+            }
+            executePlanCreation(request, userId, userOrgId, response);
+        } catch (Exception e) {
+            handleException(response, userOrgId, e);
+        }
+        return response;
+    }
+
+    private void executePlanCreation(ApiRequest request, String userId, String userOrgId, ApiResponse response) {
+        try {
+            Map<String, Object> planData = dataTransformService.prepareCbPlanForInsert(request, userId);
+            ApiResponse insertResponse = insertPlanToDatabase(planData);
+            if (Constants.SUCCESS.equals(insertResponse.get(Constants.RESPONSE))) {
+                processSuccessfulCreation(planData, response);
+            } else {
+                processFailedCreation(insertResponse, userOrgId, response);
+            }
+        } catch (JsonProcessingException e) {
+            handleJsonProcessingException(e, userOrgId, response);
+        }
+    }
+
+    private ApiResponse insertPlanToDatabase(Map<String, Object> planData) {
+        return (ApiResponse) cassandraOperation.insertRecord(
+                Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3,
+                planData);
+    }
+
+    private void processSuccessfulCreation(Map<String, Object> planData, ApiResponse response) {
+        String planId = String.valueOf(planData.get(Constants.PLAN_ID));
+        contentLookupService.updateContentLookup(planId, planData);
+        elasticSearchService.indexToElasticSearch(planId, planData);
+        populateSuccessResponse(response, planId);
+    }
+
+    private void populateSuccessResponse(ApiResponse response, String planId) {
+        response.getResult().put(Constants.ID, planId);
+        response.getResult().put(Constants.STATUS, Constants.CREATED);
+        response.setResponseCode(HttpStatus.CREATED);
+        log.info("CbPlanServiceV3Impl.createCbPlan: Successfully created CB Plan with ID: {}", planId);
+    }
+
+    private void processFailedCreation(ApiResponse insertResponse, String userOrgId, ApiResponse response) {
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr(Constants.ERR_FAILED_TO_CREATE_CB_PLAN + userOrgId
+                + Constants.ERR_MESSAGE_SEPARATOR + insertResponse.getParams().getErr());
+        response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+        log.error("CbPlanServiceV3Impl.createCbPlan: Insert failed for orgId: {}", userOrgId);
+    }
+
+    private void handleJsonProcessingException(JsonProcessingException e, String userOrgId, ApiResponse response) {
+        log.error("CbPlanServiceV3Impl.createCbPlan: JSON processing error for orgId: {}", userOrgId, e);
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr(e.getMessage());
+        response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private void handleException(ApiResponse response, String userOrgId, Exception e) {
+        log.error("CbPlanServiceV3Impl.createCbPlan: Exception occurred for orgId: {}", userOrgId, e);
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr(e.getMessage());
+        response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    public ApiResponse updateCbPlan(ApiRequest request, String userOrgId, String authToken, List<String> userRoles) {
+        log.info("CbPlanServiceV3Impl.updateCbPlan: Updating CB Plan for orgId: {}", userOrgId);
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_CB_PLAN_UPDATE);
+        try {
+            String userId = validationService.validateAndExtractUserId(authToken, response);
+            if (StringUtils.isEmpty(userId)) {
+                return response;
+            }
+            if (!validationService.validatePlanIdExists(request, response)) {
+                return response;
+            }
+            executeUpdateFlow(request, userId, userOrgId, userRoles, response);
+        } catch (Exception e) {
+            handleUpdateException(response, userOrgId, e);
+        }
+        return response;
+    }
+
+    private void executeUpdateFlow(ApiRequest request, String userId, String userOrgId,
+                                   List<String> userRoles, ApiResponse response) throws JsonProcessingException {
+        Map<String, Object> updatedCbPlan = (Map<String, Object>) request.getRequest();
+        String cbPlanId = (String) updatedCbPlan.get(Constants.ID);
+        Map<String, Object> existingCbPlan = fetchExistingPlan(cbPlanId, response);
+        if (MapUtils.isEmpty(existingCbPlan)) {
+            return;
+        }
+        if (validationService.isUnauthorizedToUpdate(userId, existingCbPlan, userRoles, response)) {
+            return;
+        }
+        executeAuthorizedUpdate(request, userId, userOrgId, updatedCbPlan, existingCbPlan, response);
+    }
+
+    private Map<String, Object> fetchExistingPlan(String cbPlanId, ApiResponse response) {
+        List<Map<String, Object>> cbPlanMapInfo = cassandraOperation.getRecordsByProperties(
+                Constants.KEYSPACE_SUNBIRD, Constants.TABLE_CB_PLAN_V3,
+                Map.of(Constants.PLAN_ID, cbPlanId), null, serverProperties.getCassandraQueryLimitPrimaryKey());
+        if (CollectionUtils.isEmpty(cbPlanMapInfo)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(Constants.ERR_CB_PLAN_NOT_FOUND + cbPlanId);
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return Collections.emptyMap();
+        }
+        return cbPlanMapInfo.get(0);
+    }
+
+    private void executeAuthorizedUpdate(ApiRequest request, String userId, String userOrgId,
+                                         Map<String, Object> updatedCbPlan, Map<String, Object> existingCbPlan,
+                                         ApiResponse response) throws JsonProcessingException {
+        String rootOrgId = validationService.validateUserOrganization(userId, response);
+        if (StringUtils.isEmpty(rootOrgId)) {
+            return;
+        }
+        boolean isCCA = validationService.validateOrgCCA(rootOrgId, response);
+        if (Constants.FAILED.equalsIgnoreCase(response.getParams().getStatus())) {
+            return;
+        }
+        String existingStatus = (String) existingCbPlan.get(Constants.STATUS);
+        if (Constants.LIVE.equalsIgnoreCase(existingStatus)) {
+            handleUpdateOfLiveCbPlan(response, updatedCbPlan, existingCbPlan, userId, rootOrgId, isCCA);
+        } else if (Constants.DRAFT.equalsIgnoreCase(existingStatus)) {
+            handleUpdateOfDraftCbPlan(request, userId, userOrgId, updatedCbPlan, existingCbPlan,
+                    isCCA, response);
+        }
+    }
+
+    private void handleUpdateOfDraftCbPlan(ApiRequest request, String userId, String userOrgId,
+                                           Map<String, Object> updatedCbPlan, Map<String, Object> existingCbPlan,
+                                           boolean isCCA, ApiResponse response) throws JsonProcessingException {
+        List<String> validations = requestValidator.validateCbPlanCreateRequest(request, isCCA, userOrgId, false);
+        if (CollectionUtils.isNotEmpty(validations)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(mapper.writeValueAsString(validations));
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return;
+        }
+        String cbPlanId = (String) updatedCbPlan.get(Constants.ID);
+        Map<String, Object> updatedRequest = dataTransformService.prepareCbPlanForUpdate(updatedCbPlan, userId);
+        executeDraftPlanUpdate(cbPlanId, updatedRequest, existingCbPlan, response);
+    }
+
+    private void executeDraftPlanUpdate(String cbPlanId, Map<String, Object> updatedRequest,
+                                        Map<String, Object> existingCbPlan, ApiResponse response) {
+        Map<String, Object> resp = cassandraOperation.updateRecord(Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3, updatedRequest, Map.of(Constants.PLAN_ID, cbPlanId));
+        if (Constants.SUCCESS.equals(resp.get(Constants.RESPONSE))) {
+            processDraftUpdateSuccess(cbPlanId, updatedRequest, existingCbPlan, response);
+        } else {
+            processDraftUpdateFailure(cbPlanId, response);
+        }
+    }
+
+    private void processDraftUpdateSuccess(String cbPlanId, Map<String, Object> updatedRequest,
+                                           Map<String, Object> existingCbPlan, ApiResponse response) {
+        contentLookupService.updateContentLookupForModifiedPlan(cbPlanId, updatedRequest, existingCbPlan);
+        elasticSearchService.updateElasticSearchForPlan(cbPlanId, updatedRequest);
+        response.getResult().put(Constants.STATUS, Constants.UPDATED);
+    }
+
+    private void processDraftUpdateFailure(String cbPlanId, ApiResponse response) {
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr(Constants.ERR_CB_PLAN_NOT_FOUND + cbPlanId);
+        response.setResponseCode(HttpStatus.BAD_REQUEST);
+    }
+
+    private void handleUpdateOfLiveCbPlan(ApiResponse response, Map<String, Object> incomingCbPlanRequest,
+                                          Map<String, Object> existingCbPlan, String userId,
+                                          String rootOrgId, boolean isCCA) {
+        try {
+            Set<String> rootOrgIdsInContextData = new HashSet<>();
+            if (!validationService.validateContextDataForLivePlan(incomingCbPlanRequest, isCCA, rootOrgId,
+                    rootOrgIdsInContextData, response)) {
+                return;
+            }
+            Map<String, Object> updatedCbPlan = dataTransformService.buildUpdatedPlanForLive(incomingCbPlanRequest, existingCbPlan,
+                    userId, rootOrgIdsInContextData, response);
+            if (MapUtils.isEmpty(updatedCbPlan)) {
+                return;
+            }
+            saveLivePlanAsDraft(updatedCbPlan, existingCbPlan, response);
+        } catch (JsonProcessingException e) {
+            handleLivePlanUpdateException(e, response);
+        }
+    }
+
+    private void saveLivePlanAsDraft(Map<String, Object> updatedCbPlan, Map<String, Object> existingCbPlan,
+                                     ApiResponse response) throws JsonProcessingException {
+        String draftData = mapper.writeValueAsString(updatedCbPlan);
+        String planId = (String) existingCbPlan.get(Constants.PLAN_ID);
+        Map<String, Object> resp = cassandraOperation.updateRecord(Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3, Map.of(Constants.DRAFT_DATA, draftData),
+                Map.of(Constants.PLAN_ID, planId));
+        if (Constants.SUCCESS.equals(resp.get(Constants.RESPONSE))) {
+            response.getResult().put(Constants.STATUS, Constants.UPDATED);
+            response.getResult().put(Constants.MESSAGE, String.format(Constants.MSG_UPDATED_AS_DRAFT, planId));
+        } else {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr((String) resp.get(Constants.ERROR_MESSAGE) + " for cbPlanId: " + planId);
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void handleLivePlanUpdateException(JsonProcessingException e, ApiResponse response) {
+        log.error("CbPlanServiceV3Impl.handleUpdateOfLiveCbPlan: {}", Constants.ERR_SERIALIZING_CB_PLAN, e);
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr(Constants.ERR_PROCESSING_CB_PLAN_DATA);
+        response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private void handleUpdateException(ApiResponse response, String userOrgId, Exception e) {
+        log.error("CbPlanServiceV3Impl.updateCbPlan: {} {}", Constants.ERR_FAILED_TO_UPDATE_CB_PLAN, userOrgId, e);
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr(e.getMessage());
+        response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    public ApiResponse publishCbPlan(ApiRequest request, String userOrgId, String authToken, List<String> userRoles) {
+        log.info("CbPlanServiceV3Impl.publishCbPlan: Publishing CB Plan for orgId: {}", userOrgId);
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_CB_PLAN_PUBLISH);
+        try {
+            String userId = validationService.validateAndExtractUserId(authToken, response);
+            if (StringUtils.isEmpty(userId)) {
+                return response;
+            }
+            Map<String, Object> incomingRequest = (Map<String, Object>) request.getRequest();
+            String cbPlanId = validationService.validateAndExtractPlanId(incomingRequest, response);
+            if (StringUtils.isEmpty(cbPlanId)) {
+                return response;
+            }
+            Map<String, Object> existingCbPlan = fetchExistingPlan(cbPlanId, response);
+            if (MapUtils.isEmpty(existingCbPlan)) {
+                return response;
+            }
+            if (validationService.isUnauthorizedToUpdate(userId, existingCbPlan, userRoles, response)) {
+                return response;
+            }
+            executePublishFlow(request, userId, userOrgId, cbPlanId, existingCbPlan, response);
+        } catch (Exception e) {
+            handlePublishException(response, userOrgId, e);
+        }
+        return response;
+    }
+
+    private void executePublishFlow(ApiRequest request, String userId, String userOrgId,
+                                    String cbPlanId, Map<String, Object> existingCbPlan,
+                                    ApiResponse response) throws JsonProcessingException {
+        String rootOrgId = validationService.validateUserOrganization(userId, response);
+        if (StringUtils.isEmpty(rootOrgId)) {
+            return;
+        }
+        boolean isCCA = validationService.validateOrgCCA(rootOrgId, response);
+        if (Constants.FAILED.equalsIgnoreCase(response.getParams().getStatus())) {
+            return;
+        }
+        Map<String, Object> incomingRequest = (Map<String, Object>) request.getRequest();
+        String existingStatus = (String) existingCbPlan.get(Constants.STATUS);
+        String planYear = (String) existingCbPlan.get(Constants.PLAN_YEAR);
+        Map<String, Object> updatedRequest = preparePublishUpdate(incomingRequest, existingCbPlan,
+                existingStatus, userId, isCCA, userOrgId, response);
+        if (MapUtils.isEmpty(updatedRequest)) {
+            return;
+        }
+        executePublishTransaction(cbPlanId, planYear, updatedRequest, existingCbPlan, existingStatus, response);
+    }
+
+    private Map<String, Object> preparePublishUpdate(Map<String, Object> incomingRequest,
+                                                     Map<String, Object> existingCbPlan,
+                                                     String existingStatus, String userId,
+                                                     boolean isCCA, String userOrgId,
+                                                     ApiResponse response) throws JsonProcessingException {
+        String comment = (String) incomingRequest.get(Constants.COMMENT);
+        Map<String, Object> updatedRequest = new HashMap<>();
+        updatedRequest.put(Constants.PUBLISHED_AT, Instant.now());
+        updatedRequest.put(Constants.PUBLISHED_BY, userId);
+        updatedRequest.put(Constants.UPDATED_AT, Instant.now());
+        updatedRequest.put(Constants.COMMENT, comment);
+        updatedRequest.put(Constants.UPDATED_BY, userId);
+        if (Constants.LIVE.equalsIgnoreCase(existingStatus)) {
+            return handleLivePlanPublish(existingCbPlan, incomingRequest, isCCA, userOrgId,
+                    updatedRequest, response);
+        } else if (Constants.DRAFT.equalsIgnoreCase(existingStatus)) {
+            return handleDraftPlanPublish(existingCbPlan, isCCA, userOrgId, updatedRequest, response);
+        } else {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr("CbPlan is in invalid state for publish. Status: " + existingStatus);
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return Collections.emptyMap();
+        }
+    }
+
+    private Map<String, Object> prepareCbPlanForRePublish(Map<String, Object> existingCbPlan,
+                                                          Map<String, Object> incomingRequest) throws JsonProcessingException {
+        Map<String, Object> dataInDraftObject = Objects.nonNull(existingCbPlan.get(Constants.DRAFT_DATA))
+                ? mapper.readValue((String) existingCbPlan.get(Constants.DRAFT_DATA),
+                new TypeReference<Map<String, Object>>() {
+                })
+                : new HashMap<>();
+        if (MapUtils.isEmpty(dataInDraftObject)) {
+            return dataInDraftObject;
+        }
+        if (incomingRequest.containsKey(Constants.COMMENT)) {
+            dataInDraftObject.put(Constants.COMMENT, incomingRequest.get(Constants.COMMENT));
+        }
+        dataInDraftObject.put(Constants.DRAFT_DATA, null);
+        return dataInDraftObject;
+    }
+
+    private Map<String, Object> handleLivePlanPublish(Map<String, Object> existingCbPlan,
+                                                      Map<String, Object> incomingRequest,
+                                                      boolean isCCA, String userOrgId,
+                                                      Map<String, Object> updatedRequest,
+                                                      ApiResponse response) throws JsonProcessingException {
+        Set<String> existingRootOrgIdsInCriteria = new HashSet<>();
+        Set<String> rootOrgIdsInCriteria = new HashSet<>();
+        requestValidator.validateContextData(existingCbPlan, isCCA, userOrgId, existingRootOrgIdsInCriteria, false);
+        updatedRequest.putAll(prepareCbPlanForRePublish(existingCbPlan, incomingRequest));
+        if (updatedRequest.containsKey(Constants.CONTEXT_DATA_REQUEST)) {
+            List<String> errors = requestValidator.validateContextData(updatedRequest, isCCA, userOrgId,
+                    rootOrgIdsInCriteria, false);
+            if (CollectionUtils.isNotEmpty(errors)) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr(mapper.writeValueAsString(errors));
+                response.setResponseCode(HttpStatus.BAD_REQUEST);
+                return Collections.emptyMap();
+            }
+        }
+        updatedRequest.remove(Constants.ROOT_ORG_IDS_IN_CONTEXT_DATA);
+        updatedRequest.put(Constants.DRAFT_DATA, mapper.writeValueAsString(Collections.emptyMap()));
+        updatedRequest.put(Constants.EXISTING_ROOT_ORG_IDS, existingRootOrgIdsInCriteria);
+        updatedRequest.put(Constants.NEW_ROOT_ORG_IDS, rootOrgIdsInCriteria);
+        return updatedRequest;
+    }
+
+    private Map<String, Object> handleDraftPlanPublish(Map<String, Object> existingCbPlan, boolean isCCA,
+                                                       String userOrgId, Map<String, Object> updatedRequest,
+                                                       ApiResponse response) throws JsonProcessingException {
+        Set<String> rootOrgIdsInCriteria = new HashSet<>();
+        updatedRequest.put(Constants.STATUS, Constants.LIVE);
+        updatedRequest.put(Constants.END_DATE_REQUEST, dataTransformService.parseEndDate(existingCbPlan.get(Constants.END_DATE_REQUEST)));
+        List<String> errors = requestValidator.validateContextData(existingCbPlan, isCCA, userOrgId,
+                rootOrgIdsInCriteria, false);
+        if (CollectionUtils.isNotEmpty(errors)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(mapper.writeValueAsString(errors));
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return Collections.emptyMap();
+        }
+        updatedRequest.put(Constants.ORG_SCOPE, existingCbPlan.get(Constants.ORG_SCOPE));
+        updatedRequest.put(Constants.NEW_ROOT_ORG_IDS, rootOrgIdsInCriteria);
+        updatedRequest.put(Constants.EXISTING_ROOT_ORG_IDS, Collections.emptySet());
+        return updatedRequest;
+    }
+
+    private void executePublishTransaction(String cbPlanId, String planYear, Map<String, Object> updatedRequest,
+                                           Map<String, Object> existingCbPlan, String existingStatus,
+                                           ApiResponse response) {
+        Map<String, Object> sanitizedMap = elasticSearchService.sanitizeForElastic(updatedRequest);
+        Map<String, Object> sanitizedExisting = elasticSearchService.sanitizeForElastic(existingCbPlan);
+        Map<String, Object> resp = cassandraOperation.updateRecord(
+                Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3,
+                updatedRequest,
+                Map.of(Constants.PLAN_ID, cbPlanId),
+                () -> Objects.nonNull(esUtilService.updateDocument(serverProperties.getCpPlanIndex(), Constants.INDEX_TYPE,
+                        cbPlanId, sanitizedMap, serverProperties.getElasticCbPlanJsonPath())),
+                () -> {
+                    String rollbackResult = esUtilService.updateDocument(serverProperties.getCpPlanIndex(),
+                            Constants.INDEX_TYPE, cbPlanId, sanitizedExisting,
+                            serverProperties.getElasticCbPlanJsonPath());
+                    if (Objects.isNull(rollbackResult)) {
+                        log.error("ES_CASSANDRA_DIVERGENCE: failed to roll back ES document for cbPlanId={} "
+                                + "after Cassandra commit failure — manual reconciliation required", cbPlanId);
+                    }
+                });
+        if (Constants.SUCCESS.equals(resp.get(Constants.RESPONSE))) {
+            updateOrgLookupTables(cbPlanId, planYear, updatedRequest, existingCbPlan, existingStatus, response);
+        } else {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr((String) resp.get(Constants.ERROR_MESSAGE) + " for cbPlanId: " + cbPlanId);
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void updateOrgLookupTables(String cbPlanId, String planYear, Map<String, Object> updatedRequest,
+                                       Map<String, Object> existingCbPlan, String existingStatus,
+                                       ApiResponse response) {
+        String orgScope = (String) updatedRequest.getOrDefault(Constants.ORG_SCOPE,
+                existingCbPlan.get(Constants.ORG_SCOPE));
+        Instant endDate = (Instant) updatedRequest.getOrDefault(Constants.END_DATE_REQUEST,
+                existingCbPlan.get(Constants.END_DATE_REQUEST));
+        Set<String> newRootOrgIds = (Set<String>) updatedRequest.get(Constants.NEW_ROOT_ORG_IDS);
+        Set<String> existingRootOrgIds = (Set<String>) updatedRequest.get(Constants.EXISTING_ROOT_ORG_IDS);
+        String existingOrgScope = (String) existingCbPlan.get(Constants.ORG_SCOPE);
+        if (Constants.SINGLE.equalsIgnoreCase(orgScope) || Constants.CUSTOM.equalsIgnoreCase(orgScope)) {
+            ApiResponse lookupResp = orgLookupService.upsertCustomOrgLookup(cbPlanId, planYear, newRootOrgIds, endDate, true);
+            if (!Constants.SUCCESS.equals(lookupResp.get(Constants.RESPONSE))) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr(lookupResp.getParams().getErr());
+                response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+                return;
+            }
+        } else if (Constants.ALL.equalsIgnoreCase(orgScope)) {
+            ApiResponse allResp = orgLookupService.upsertAllOrgLookup(cbPlanId, planYear, endDate, true);
+            if (!Constants.SUCCESS.equals(allResp.get(Constants.RESPONSE))) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr(allResp.getParams().getErr());
+                response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+                return;
+            }
+        }
+        if (Constants.LIVE.equalsIgnoreCase(existingStatus)) {
+            orgLookupService.handleOrgLookupChanges(cbPlanId, planYear, existingRootOrgIds, newRootOrgIds,
+                    existingOrgScope, response);
+        }
+    }
+
+    private void handlePublishException(ApiResponse response, String userOrgId, Exception e) {
+        log.error("CbPlanServiceV3Impl.publishCbPlan: Failed to publish CB Plan for orgId: {}", userOrgId, e);
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr(e.getMessage());
+        response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    public ApiResponse retireCbPlan(ApiRequest request, String userOrgId, String authToken, List<String> userRoles) {
+        log.info("CbPlanServiceV3Impl.retireCbPlan: Archiving CB Plan for orgId: {}", userOrgId);
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_CB_PLAN_RETIRE);
+        try {
+            String userId = validationService.validateAndExtractUserId(authToken, response);
+            if (StringUtils.isEmpty(userId)) {
+                return response;
+            }
+            Map<String, Object> requestData = (Map<String, Object>) request.getRequest();
+            String cbPlanId = extractPlanIdFromRequest(requestData, response);
+            if (StringUtils.isEmpty(cbPlanId)) {
+                return response;
+            }
+            String comment = (String) requestData.get(Constants.COMMENT);
+            Map<String, Object> existingCbPlan = fetchExistingPlan(cbPlanId, response);
+            if (MapUtils.isEmpty(existingCbPlan)) {
+                return response;
+            }
+            if (validationService.isUnauthorizedToUpdate(userId, existingCbPlan, userRoles, response)) {
+                return response;
+            }
+            if (validationService.isAlreadyArchived(existingCbPlan, cbPlanId, response)) {
+                return response;
+            }
+            executeArchiveFlow(cbPlanId, comment, userId, existingCbPlan, response);
+        } catch (Exception e) {
+            handleArchiveException(response, userOrgId, e);
+        }
+        return response;
+    }
+
+    private String extractPlanIdFromRequest(Map<String, Object> requestData, ApiResponse response) {
+        Object planIdObj = requestData.get(Constants.ID);
+        if (Objects.isNull(planIdObj)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr("CbPlanId is missing.");
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return null;
+        }
+        String cbPlanId = planIdObj.toString();
+        if (StringUtils.isBlank(cbPlanId)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr("CbPlanId is missing.");
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return null;
+        }
+        return cbPlanId;
+    }
+
+    private void executeArchiveFlow(String cbPlanId, String comment, String userId,
+                                    Map<String, Object> existingCbPlan, ApiResponse response) {
+        String planYear = (String) existingCbPlan.get(Constants.PLAN_YEAR);
+        Map<String, Object> updateData = dataTransformService.prepareArchiveUpdate(comment, userId);
+        Map<String, Object> resp = cassandraOperation.updateRecord(
+                Constants.KEYSPACE_SUNBIRD,
+                Constants.TABLE_CB_PLAN_V3,
+                updateData,
+                Map.of(Constants.PLAN_ID, cbPlanId));
+        if (Constants.SUCCESS.equals(resp.get(Constants.RESPONSE))) {
+            processSuccessfulArchive(cbPlanId, planYear, existingCbPlan, updateData, response);
+        } else {
+            processFailedArchive(cbPlanId, resp, response);
+        }
+    }
+
+    private void processSuccessfulArchive(String cbPlanId, String planYear, Map<String, Object> existingCbPlan,
+                                          Map<String, Object> updateData, ApiResponse response) {
+        contentLookupService.removeFromContentLookup(cbPlanId, existingCbPlan);
+        elasticSearchService.updateElasticSearchForArchive(cbPlanId, existingCbPlan, updateData);
+        orgLookupService.deactivateOrgLookupEntries(cbPlanId, planYear, existingCbPlan, response);
+        if (Constants.SUCCESS.equalsIgnoreCase(response.getParams().getStatus())
+                || Objects.isNull(response.getParams().getStatus())) {
+            response.getResult().put(Constants.STATUS, Constants.UPDATED);
+            response.getResult().put(Constants.MESSAGE, "Archived cbPlan for cbPlanId: " + cbPlanId);
+        }
+    }
+
+    private void processFailedArchive(String cbPlanId, Map<String, Object> resp, ApiResponse response) {
+        response.getParams().setStatus(Constants.FAILED);
+        String errorMsg = String.format("%s for cbPlanId: %s", resp.get(Constants.ERROR_MESSAGE), cbPlanId);
+        response.getParams().setErr(errorMsg);
+        response.setResponseCode(HttpStatus.BAD_REQUEST);
+    }
+
+    private void handleArchiveException(ApiResponse response, String userOrgId, Exception e) {
+        log.error("CbPlanServiceV3Impl.retireCbPlan: Failed to archive CB Plan for orgId: {}", userOrgId, e);
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr(e.getMessage());
+        response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    public ApiResponse searchCbPlan(SearchCriteria searchCriteria, String userOrgId, String authToken) {
+        log.info("CbPlanServiceV3Impl.searchCbPlan: Searching CB Plans for orgId: {}", userOrgId);
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_COMMUNITY_SEARCH);
+        try {
+            String userId = validationService.validateAndExtractUserId(authToken, response);
+            if (StringUtils.isEmpty(userId)) {
+                return response;
+            }
+            SearchResult searchResult = esUtilService.searchDocuments(
+                    serverProperties.getCpPlanIndex(),
+                    searchCriteria,
+                    serverProperties.getElasticCbPlanJsonPath());
+            if (CollectionUtils.isNotEmpty(searchResult.getData())) {
+                List<Map<String, Object>> enrichedData = enrichmentService.enrichSearchResults(searchResult.getData());
+                searchResult.setData(enrichedData);
+                response.getResult().put(Constants.RESULT, searchResult);
+                createSuccessResponse(response);
+            }
+        } catch (Exception e) {
+            handleSearchException(response, userOrgId, e);
+        }
+        return response;
+    }
+
+    private void createSuccessResponse(ApiResponse response) {
+        response.setParams(new ApiRespParam());
+        response.getParams().setStatus(Constants.SUCCESS);
+        response.setResponseCode(HttpStatus.OK);
+    }
+
+    private void handleSearchException(ApiResponse response, String userOrgId, Exception e) {
+        log.error("CbPlanServiceV3Impl.searchCbPlan: Error occurred while searching for orgId: {}", userOrgId, e);
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr("Error while processing search");
+        response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Gets CB Plan dictionary for a user - groups content IDs by APAR/non-APAR
+     * with plan occurrences and optional enrichment.
+     * Caching strategy: Two-tier (Redis user-specific + Caffeine plan-level) to handle
+     * 60K TPS. Redis stores plan IDs per user/year; Caffeine caches full plan data.
+     *
+     * @param request   API request containing planYear (optional) and enrichment (optional)
+     * @param authToken authentication token
+     * @return ApiResponse with aparContentList, nonAparContentList, and optionally enrichedContentList
+     */
+    @Override
+    public ApiResponse getCBPlanDictionaryForUser(ApiRequest request, String authToken) {
+        log.debug("getCBPlanDictionaryForUser: Entry");
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_CBPLAN_V3_GET_USER_DICTIONARY);
+        try {
+            String userId = accessTokenValidator.fetchUserIdFromAccessToken(authToken, response);
+            if (StringUtils.isBlank(userId)) {
+                log.warn("getCBPlanDictionaryForUser: Authentication failed - invalid or missing token");
+                response.getParams().setErr("Invalid or missing authentication token");
+                response.setResponseCode(HttpStatus.UNAUTHORIZED);
+                return response;
+            }
+            Map<String, Object> requestData = (Map<String, Object>) request.getRequest();
+            if (Objects.isNull(requestData)) {
+                requestData = new HashMap<>();
+            }
+            String requestedPlanYear = (String) requestData.get(Constants.REQUEST_PARAM_PLAN_YEAR);
+            Boolean enrichment = (Boolean) requestData.get(Constants.REQUEST_PARAM_ENRICHMENT);
+            boolean isEnrichmentEnabled = Boolean.TRUE.equals(enrichment);
+            String planYear = resolvePlanYear(requestedPlanYear, response);
+            if (Objects.isNull(planYear)) {
+                return response;
+            }
+            String redisCacheKey = Constants.CB_PLAN_REDIS_KEY_PREFIX + userId + ":" + planYear + ":dict";
+            CbPlanDictionaryCacheEntry cacheEntry = getCachedDictionaryEntry(redisCacheKey);
+            if (Objects.nonNull(cacheEntry)) {
+                log.info("getCBPlanDictionaryForUser: Cache hit - userId={}, planYear={}, aparCount={}, nonAparCount={}",
+                        userId, planYear, cacheEntry.getAparCount(), cacheEntry.getNonAparCount());
+                enrichAndPopulateResponse(response, cacheEntry, isEnrichmentEnabled);
+                log.info("getCBPlanDictionaryForUser: Success - userId={}, aparCount={}, nonAparCount={}",
+                        userId, cacheEntry.getAparCount(), cacheEntry.getNonAparCount());
+                return response;
+            }
+            Map<String, String> userProfile = buildUserProfile(userId, response);
+            if (userProfile.isEmpty()) {
+                return response;
+            }
+            String userOrgId = userProfile.get(Constants.USER_ROOT_ORG_ID);
+            log.info("getCBPlanDictionaryForUser: Cache miss - userId={}, orgId={}, planYear={}",
+                    userId, userOrgId, planYear);
+            cacheEntry = computeDictionaryFromPlans(userId, userOrgId, planYear, redisCacheKey, response);
+            if (Objects.isNull(cacheEntry)) {
+                populateEmptyDictionaryResponse(response);
+                return response;
+            }
+            enrichAndPopulateResponse(response, cacheEntry, isEnrichmentEnabled);
+            log.info("getCBPlanDictionaryForUser: Success - userId={}, aparCount={}, nonAparCount={}",
+                    userId, cacheEntry.getAparCount(), cacheEntry.getNonAparCount());
+        } catch (Exception e) {
+            log.error("getCBPlanDictionaryForUser: Failed to fetch CB Plan dictionary - userId extracted from token", e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr("Failed to fetch CB Plan dictionary: " + e.getMessage());
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return response;
+    }
+
+    /**
+     * Resolves plan year to use: requested year if valid, else current financial year.
+     *
+     * @param requestedPlanYear plan year from request (nullable)
+     * @param response          API response for error reporting
+     * @return validated plan year in YYYY-YY format, or null if invalid
+     */
+    private String resolvePlanYear(String requestedPlanYear, ApiResponse response) {
+        if (StringUtils.isBlank(requestedPlanYear)) {
+            String currentFY = CbPlanYearUtil.resolveCurrentFinancialYear();
+            log.debug("resolvePlanYear: Using current financial year - {}", currentFY);
+            return currentFY;
+        }
+        String normalized = CbPlanYearUtil.validateAndNormalize(requestedPlanYear);
+        if (Objects.isNull(normalized)) {
+            log.warn("resolvePlanYear: Invalid format - requested={}", requestedPlanYear);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr("Invalid planYear format. Expected: YYYY-YY (e.g., '2026-27')");
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return null;
+        }
+        log.debug("resolvePlanYear: Using requested year - {}", normalized);
+        return normalized;
+    }
+
+    /**
+     * Builds user profile map with root org and personal details.
+     *
+     * @param userId   user ID
+     * @param response API response for error reporting
+     * @return user profile map with flattened keys, or empty map if user not found
+     */
+    private Map<String, String> buildUserProfile(String userId, ApiResponse response) {
+        log.debug("buildUserProfile: Fetching profile for userId={}", userId);
+        try {
+            String cacheKey = Constants.USER + ":basicProfile:" + userId;
+            String cachedData = redisCacheMgr.getFromCache(cacheKey);
+            Map<String, Object> userBasicProfile;
+            if (StringUtils.isNotBlank(cachedData)) {
+                log.debug("buildUserProfile: Redis cache HIT for userId={}", userId);
+                userBasicProfile = mapper.readValue(cachedData, new TypeReference<Map<String, Object>>() {
+                });
+                if (userBasicProfile.containsKey(Constants.PROFILE_DETAILS)) {
+                    Object profileDetailsValue = userBasicProfile.remove(Constants.PROFILE_DETAILS);
+                    userBasicProfile.put(Constants.PROFILE_DETAILS.toLowerCase(), profileDetailsValue);
+                }
+            } else {
+                log.debug("buildUserProfile: Redis cache MISS, querying Cassandra - userId={}", userId);
+                Map<String, Object> propertiesMap = Map.of(Constants.ID, userId);
+                List<String> userFields = Arrays.asList(Constants.ID, Constants.ROOT_ORG_ID, Constants.PROFILE_DETAILS);
+                List<Map<String, Object>> userList = cassandraOperation.getRecordsByProperties(
+                        Constants.KEYSPACE_SUNBIRD, Constants.USER, propertiesMap, userFields,
+                        serverProperties.getCassandraQueryLimitPrimaryKey());
+                if (CollectionUtils.isEmpty(userList)) {
+                    log.warn("buildUserProfile: User not found - userId={}", userId);
+                    response.getParams().setStatus(Constants.FAILED);
+                    response.getParams().setErr("User does not exist");
+                    response.setResponseCode(HttpStatus.BAD_REQUEST);
+                    return Map.of();
+                }
+                userBasicProfile = userList.get(0);
+            }
+            Map<String, String> userProfile = new HashMap<>();
+            setUserProfileFromBasicData(userProfile, userBasicProfile);
+            log.debug("buildUserProfile: Profile built - userId={}, orgId={}", userId, userProfile.get(Constants.USER_ROOT_ORG_ID));
+            return userProfile;
+        } catch (Exception e) {
+            log.error("Error building user profile for userId: {}", userId, e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr("Error fetching user profile");
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+            return Map.of();
+        }
+    }
+
+    private void setUserProfileFromBasicData(Map<String, String> userProfile, Map<String, Object> userBasicProfile)
+            throws JsonProcessingException {
+        if (MapUtils.isEmpty(userBasicProfile)) {
+            log.warn("User basic profile is empty");
+            return;
+        }
+        userProfile.put(Constants.USER, (String) userBasicProfile.get(Constants.ID));
+        userProfile.put(Constants.USER_ROOT_ORG_ID, (String) userBasicProfile.get(Constants.ROOT_ORG_ID));
+        Object rawValue = userBasicProfile.get(Constants.PROFILE_DETAILS.toLowerCase());
+        if (Objects.isNull(rawValue)) {
+            log.warn("profileDetails is null for userId: {}", userBasicProfile.get(Constants.ID));
+            return;
+        }
+        Map<String, Object> profileDetails = parseProfileDetails(rawValue);
+        if (MapUtils.isEmpty(profileDetails)) {
+            return;
+        }
+        extractProfessionalDetails(userProfile, profileDetails);
+        userProfile.put(Constants.PROFILE_STATUS_LOWER_KEY,
+                (String) profileDetails.get(Constants.PROFILE_STATUS_KEY));
+        extractCadreDetails(userProfile, profileDetails);
+        extractExtendedProfile(userProfile, (String) userBasicProfile.get(Constants.ID),
+                (String) userBasicProfile.get(Constants.ROOT_ORG_ID));
+    }
+
+    private Map<String, Object> parseProfileDetails(Object rawValue) throws JsonProcessingException {
+        if (rawValue instanceof String str && StringUtils.isNotBlank(str)) {
+            return mapper.readValue(str, new TypeReference<Map<String, Object>>() {
+            });
+        } else if (rawValue instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        } else {
+            try {
+                return mapper.convertValue(rawValue, new TypeReference<Map<String, Object>>() {
+                });
+            } catch (Exception e) {
+                log.error("Failed to convert profileDetails", e);
+                return Map.of();
+            }
+        }
+    }
+
+    private void extractProfessionalDetails(Map<String, String> userProfile, Map<String, Object> profileDetails) {
+        List<Map<String, Object>> professionalDetailList =
+                (List<Map<String, Object>>) profileDetails.get(Constants.PROFESSIONAL_DETAILS);
+        if (CollectionUtils.isNotEmpty(professionalDetailList)) {
+            Map<String, Object> professionalDetails = professionalDetailList.get(0);
+            userProfile.put(Constants.DESIGNATION, (String) professionalDetails.get(Constants.DESIGNATION));
+            userProfile.put(Constants.GROUP, (String) professionalDetails.get(Constants.GROUP));
+        }
+    }
+
+    private void extractCadreDetails(Map<String, String> userProfile, Map<String, Object> profileDetails) {
+        Map<String, Object> cadreDetails = (Map<String, Object>) profileDetails.get(Constants.CADRE_DETAILS);
+        boolean centralDeputation = false;
+        if (MapUtils.isNotEmpty(cadreDetails)) {
+            userProfile.put(Constants.CADRE, (String) cadreDetails.get(Constants.CADRE_NAME));
+            userProfile.put(Constants.SERVICE, (String) cadreDetails.get(Constants.CIVIL_SERVICE_NAME));
+            if (cadreDetails.containsKey(Constants.CADRE_BATCH)) {
+                userProfile.put(Constants.BATCH, String.valueOf(cadreDetails.get(Constants.CADRE_BATCH)));
+            }
+            if (cadreDetails.containsKey(Constants.CENTRAL_DEPUTATION)) {
+                centralDeputation = (Boolean) cadreDetails.get(Constants.CENTRAL_DEPUTATION);
+            }
+        }
+        userProfile.put(Constants.CENTRAL_DEPUTATION_LOWER_KEY, String.valueOf(centralDeputation));
+    }
+
+    private void extractExtendedProfile(Map<String, String> userProfile, String userId, String rootOrgId) {
+        try {
+            Map<String, Object> propertiesMap = Map.of(
+                    Constants.USER_ID, userId,
+                    Constants.ROOT_ORG_ID, rootOrgId);
+            List<Map<String, Object>> extendedProfileList = cassandraOperation.getRecordsByProperties(
+                    Constants.KEYSPACE_SUNBIRD, Constants.TABLE_USER_EXTENDED_PROFILE, propertiesMap, List.of(),
+                    serverProperties.getCassandraQueryLimitUserExtendedProfile());
+            if (CollectionUtils.isNotEmpty(extendedProfileList)) {
+                Map<String, Object> extendedProfile = extendedProfileList.get(0);
+                for (Map.Entry<String, Object> entry : extendedProfile.entrySet()) {
+                    if (entry.getValue() instanceof String value) {
+                        userProfile.put(entry.getKey().toLowerCase(), value);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to load extended profile for userId: {}", userId, e);
+        }
+    }
+
+    /**
+     * Processes all plans for dictionary grouping by APAR/non-APAR with access control.
+     *
+     * @param activeCbPlans     list of active CB plans
+     * @param userProfile       user profile with location/cadre details
+     * @param userOrgId         user's root org ID
+     * @param aparContentMap    accumulator for APAR content
+     * @param nonAparContentMap accumulator for non-APAR content
+     * @param aparContentIds    tracking set for APAR content IDs
+     * @param plansToCache      list of accessible plan IDs for caching
+     */
+    private void processPlansForDictionary(List<Map<String, Object>> activeCbPlans,
+                                           Map<String, String> userProfile,
+                                           String userOrgId,
+                                           Map<String, List<CbPlanContentOccurrence>> aparContentMap,
+                                           Map<String, List<CbPlanContentOccurrence>> nonAparContentMap,
+                                           Set<String> aparContentIds,
+                                           List<String> plansToCache) {
+        log.debug("processPlansForDictionary: Processing {} plans", activeCbPlans.size());
+        for (Map<String, Object> cbPlan : activeCbPlans) {
+            processSinglePlan(cbPlan, userProfile, userOrgId, aparContentMap, nonAparContentMap, aparContentIds, plansToCache);
+        }
+        log.debug("processPlansForDictionary: Completed - accessiblePlans={}, aparContent={}, nonAparContent={}",
+                plansToCache.size(), aparContentMap.size(), nonAparContentMap.size());
+    }
+
+    /**
+     * Processes a single plan: evaluates access control and groups content by APAR status.
+     *
+     * @param cbPlan            CB plan to process
+     * @param userProfile       user profile for access control
+     * @param userOrgId         user's root org ID
+     * @param aparContentMap    accumulator for APAR content
+     * @param nonAparContentMap accumulator for non-APAR content
+     * @param aparContentIds    tracking set for APAR content IDs
+     * @param plansToCache      list of accessible plan IDs for caching
+     */
+    private void processSinglePlan(Map<String, Object> cbPlan,
+                                   Map<String, String> userProfile,
+                                   String userOrgId,
+                                   Map<String, List<CbPlanContentOccurrence>> aparContentMap,
+                                   Map<String, List<CbPlanContentOccurrence>> nonAparContentMap,
+                                   Set<String> aparContentIds,
+                                   List<String> plansToCache) {
+        try {
+            if (!evaluateAccessControl(cbPlan, userProfile)) {
+                log.debug("processSinglePlan: Access denied - planId={}", cbPlan.get(Constants.PLAN_ID));
+                return;
+            }
+            String planId = (String) cbPlan.get(Constants.PLAN_ID);
+            Instant endDate = (Instant) cbPlan.get(Constants.END_DATE_KEY);
+            boolean isApar = Boolean.TRUE.equals(cbPlan.get(Constants.IS_APAR));
+            List<String> contentList = (List<String>) cbPlan.get(Constants.CONTENT_LIST);
+            if (CollectionUtils.isEmpty(contentList)) {
+                log.debug("processSinglePlan: Empty content list - planId={}", planId);
+                return;
+            }
+            plansToCache.add(planId);
+            log.debug("processSinglePlan: Processing content - planId={}, isApar={}, contentCount={}",
+                    planId, isApar, contentList.size());
+            ContentProcessingContext context = new ContentProcessingContext(
+                    planId, endDate, isApar, userProfile, userOrgId,
+                    aparContentMap, nonAparContentMap, aparContentIds);
+            processContentList(contentList, context);
+        } catch (Exception e) {
+            log.error("processSinglePlan: Failed to process - planId={}", cbPlan.get(Constants.PLAN_ID), e);
+        }
+    }
+
+    /**
+     * Processes content list and groups by APAR status with _rc course access control.
+     *
+     * @param contentList list of content IDs
+     * @param context     processing context with plan and user details
+     */
+    private void processContentList(List<String> contentList, ContentProcessingContext context) {
+        for (String contentId : contentList) {
+            if (StringUtils.isBlank(contentId) || !isContentAccessible(contentId, context.userProfile, context.userOrgId)) {
+                continue;
+            }
+            addContentOccurrence(contentId, context);
+        }
+    }
+
+    /**
+     * Adds content occurrence to appropriate map (APAR or non-APAR).
+     * APAR takes precedence - content in APAR plans moves all occurrences to APAR list.
+     *
+     * @param contentId content ID to add
+     * @param context   processing context with accumulator maps
+     */
+    private void addContentOccurrence(String contentId, ContentProcessingContext context) {
+        CbPlanContentOccurrence occurrence = new CbPlanContentOccurrence(context.planId, context.endDate);
+        if (context.aparContentIds.contains(contentId)) {
+            context.aparContentMap.computeIfAbsent(contentId, k -> new ArrayList<>()).add(occurrence);
+        } else if (context.isApar) {
+            context.aparContentIds.add(contentId);
+            context.aparContentMap.computeIfAbsent(contentId, k -> new ArrayList<>()).add(occurrence);
+            List<CbPlanContentOccurrence> nonAparOccurrences = context.nonAparContentMap.remove(contentId);
+            if (CollectionUtils.isNotEmpty(nonAparOccurrences)) {
+                context.aparContentMap.get(contentId).addAll(nonAparOccurrences);
+            }
+        } else {
+            context.nonAparContentMap.computeIfAbsent(contentId, k -> new ArrayList<>()).add(occurrence);
+        }
+    }
+
+    /**
+     * Context record grouping all parameters needed for content processing.
+     */
+    private record ContentProcessingContext(
+            String planId,
+            Instant endDate,
+            boolean isApar,
+            Map<String, String> userProfile,
+            String userOrgId,
+            Map<String, List<CbPlanContentOccurrence>> aparContentMap,
+            Map<String, List<CbPlanContentOccurrence>> nonAparContentMap,
+            Set<String> aparContentIds) {
+    }
+
+    /**
+     * Evaluates access control rules from plan's context data.
+     * Match-all criteria in at least one group logic.
+     *
+     * @param cbPlan      CB plan with context data
+     * @param userProfile user profile for matching
+     * @return true if user has access, false otherwise
+     */
+    private boolean evaluateAccessControl(Map<String, Object> cbPlan, Map<String, String> userProfile) {
+        Object contextDataObj = cbPlan.get(Constants.CONTEXT_DATA_REQUEST);
+        if (Objects.isNull(contextDataObj)) {
+            log.debug("evaluateAccessControl: No context data - access granted by default - planId={}",
+                    cbPlan.get(Constants.PLAN_ID));
+            return true;
+        }
+        try {
+            Map<String, Object> contextDataMap = parseContextData(contextDataObj);
+            if (MapUtils.isEmpty(contextDataMap)) {
+                return true;
+            }
+            boolean hasAccess = evaluateContextAccessRule(contextDataMap, userProfile);
+            log.debug("evaluateAccessControl: planId={}, hasAccess={}", cbPlan.get(Constants.PLAN_ID), hasAccess);
+            return hasAccess;
+        } catch (Exception e) {
+            log.error("evaluateAccessControl: Failed for planId={}", cbPlan.get(Constants.PLAN_ID), e);
+            return false;
+        }
+    }
+
+    private Map<String, Object> parseContextData(Object contextDataObj) throws JsonProcessingException {
+        if (contextDataObj instanceof String str && StringUtils.isNotBlank(str)) {
+            return mapper.readValue(str, new TypeReference<Map<String, Object>>() {
+            });
+        } else if (contextDataObj instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return Map.of();
+    }
+
+    private boolean evaluateContextAccessRule(Map<String, Object> accessSettingIdMap, Map<String, String> userProfile) {
+        if (MapUtils.isEmpty(accessSettingIdMap) || MapUtils.isEmpty(userProfile)) {
+            return false;
+        }
+        Map<String, Object> accessControl = (Map<String, Object>) accessSettingIdMap.get(Constants.ACCESS_CONTROL);
+        if (MapUtils.isEmpty(accessControl)) {
+            return false;
+        }
+        List<Map<String, Object>> userGroups = (List<Map<String, Object>>) accessControl.get(Constants.USER_GROUPS);
+        if (CollectionUtils.isEmpty(userGroups)) {
+            return false;
+        }
+        for (Map<String, Object> userGroup : userGroups) {
+            if (matchesUserGroup(userGroup, userProfile)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesUserGroup(Map<String, Object> userGroup, Map<String, String> userProfile) {
+        List<Map<String, Object>> criteriaList =
+                (List<Map<String, Object>>) userGroup.get(Constants.USER_GROUP_CRITERIA_LIST);
+        if (CollectionUtils.isEmpty(criteriaList)) {
+            return false;
+        }
+        for (Map<String, Object> criteria : criteriaList) {
+            if (!matchesCriteria(criteria, userProfile)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean matchesCriteria(Map<String, Object> criteria, Map<String, String> userProfile) {
+        String criteriaKey = ((String) criteria.get(Constants.CRITERIA_KEY)).toLowerCase().trim();
+        Object rawCriteriaValue = criteria.get(Constants.CRITERIA_VALUE);
+        if (Constants.CENTRAL_DEPUTATION.equalsIgnoreCase(criteriaKey)) {
+            boolean expectedValue = Boolean.parseBoolean(String.valueOf(rawCriteriaValue));
+            boolean actualValue = Boolean.parseBoolean(userProfile.getOrDefault(Constants.CENTRAL_DEPUTATION_LOWER_KEY, "false"));
+            return expectedValue == actualValue;
+        }
+        List<String> expectedValues = parseExpectedValues(rawCriteriaValue);
+        if (CollectionUtils.isEmpty(expectedValues)) {
+            return false;
+        }
+        String actualValue = userProfile.get(criteriaKey);
+        if (Objects.isNull(actualValue)) {
+            return false;
+        }
+        return expectedValues.stream()
+                .map(String::toLowerCase)
+                .anyMatch(expected -> expected.equals(actualValue.toLowerCase()));
+    }
+
+    private List<String> parseExpectedValues(Object rawCriteriaValue) {
+        if (rawCriteriaValue instanceof List<?> list) {
+            return list.stream()
+                    .filter(Objects::nonNull)
+                    .map(Object::toString)
+                    .toList();
+        } else if (Objects.nonNull(rawCriteriaValue)) {
+            return Collections.singletonList(rawCriteriaValue.toString());
+        }
+        return Collections.emptyList();
+    }
+
+    private boolean isContentAccessible(String contentId, Map<String, String> userProfile, String userOrgId) {
+        if (!contentId.contains(Constants.SECURE_CONTENT_SUFFIX)) {
+            return true;
+        }
+        if (!Constants.VERIFIED.equalsIgnoreCase(userProfile.get(Constants.PROFILE_STATUS_LOWER_KEY))) {
+            log.debug("Secure content {} excluded: profile not VERIFIED", contentId);
+            return false;
+        }
+        try {
+            Map<String, Object> contentDetails = contentService.readContent(contentId, null);
+            if (MapUtils.isEmpty(contentDetails)) {
+                return false;
+            }
+            Object secureSettingsObj = contentDetails.get(Constants.SECURE_SETTINGS);
+            if (!(secureSettingsObj instanceof Map)) {
+                return false;
+            }
+            Map<?, ?> secureSettings = (Map<?, ?>) secureSettingsObj;
+            Object orgListObj = secureSettings.get(Constants.ORGANISATION);
+            if (!(orgListObj instanceof List)) {
+                return false;
+            }
+            List<String> secureOrgList = ((List<?>) orgListObj).stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .toList();
+            return secureOrgList.contains(userOrgId);
+        } catch (Exception e) {
+            log.error("Error checking secure content accessibility: {}", contentId, e);
+            return false;
+        }
+    }
+
+    private Map<String, Object> enrichContentList(Map<String, List<CbPlanContentOccurrence>> aparContentMap,
+                                                  Map<String, List<CbPlanContentOccurrence>> nonAparContentMap) {
+        Set<String> allContentIds = new HashSet<>();
+        allContentIds.addAll(aparContentMap.keySet());
+        allContentIds.addAll(nonAparContentMap.keySet());
+        List<String> allowedFields = serverProperties.getCbPlanEnrichedContentFieldsList();
+        Map<String, Object> enrichedMap = allContentIds.stream()
+                .map(contentId -> {
+                    try {
+                        Map<String, Object> contentDetails = getContentMetadata(contentId);
+                        contentDetails.remove(Constants.CACHE_FLAG_FROM_CACHE);
+                        Map<String, Object> filteredDetails = filterContentFields(contentDetails, allowedFields);
+                        return Map.entry(contentId, filteredDetails);
+                    } catch (Exception e) {
+                        log.error("Failed to enrich content: {}", contentId, e);
+                        return null;
+                    }
+                })
+                .filter(entry -> entry != null && MapUtils.isNotEmpty(entry.getValue()))
+                .collect(LinkedHashMap::new,
+                        (map, entry) -> map.put(entry.getKey(), entry.getValue()),
+                        LinkedHashMap::putAll);
+        log.debug("Enriched {} out of {} unique content IDs", enrichedMap.size(), allContentIds.size());
+        return enrichedMap;
+    }
+
+    private Map<String, Object> filterContentFields(Map<String, Object> contentDetails, List<String> allowedFields) {
+        if (MapUtils.isEmpty(contentDetails) || allowedFields.isEmpty()) {
+            return contentDetails;
+        }
+        return contentDetails.entrySet().stream()
+                .filter(entry -> allowedFields.contains(entry.getKey()))
+                .collect(LinkedHashMap::new,
+                        (map, entry) -> map.put(entry.getKey(), entry.getValue()),
+                        LinkedHashMap::putAll);
+    }
+
+    /**
+     * Gets content metadata from Redis cache first, falls back to extended content read API if not cached.
+     * Uses the same Redis key format as the extended content read API in knowledge-platform.
+     * Redis key: extended_read_content_{contentId}
+     * API endpoint: GET /content/v1/extended/read/{contentId}
+     *
+     * @param contentId content ID
+     * @return content metadata map, or empty map if not found
+     * @throws JsonProcessingException if deserialization fails
+     */
+    private Map<String, Object> getContentMetadata(String contentId) throws JsonProcessingException {
+        String cacheKey = Constants.EXTENDED_READ_CONTENT_CACHE_KEY_PREFIX + contentId;
+        String cachedContent = redisCacheMgr.getFromCache(cacheKey);
+        if (StringUtils.isNotBlank(cachedContent)) {
+            log.debug("getContentMetadata: Redis cache hit - contentId={}, cacheKey={}", contentId, cacheKey);
+            Map<String, Object> contentDetails = mapper.readValue(cachedContent, new TypeReference<Map<String, Object>>() {
+            });
+            contentDetails.put("_fromCache", true);
+            return contentDetails;
+        }
+        log.debug("getContentMetadata: Redis cache miss, calling extended content read API - contentId={}, cacheKey={}",
+                contentId, cacheKey);
+        Map<String, Object> contentDetails = contentLookupService.getContentMetadata(contentId);
+        return Objects.nonNull(contentDetails) ? contentDetails : new HashMap<>();
+    }
+
+    private void populateEmptyDictionaryResponse(ApiResponse response) {
+        response.getResult().put(Constants.RESPONSE_KEY_APAR_COUNT, 0);
+        response.getResult().put(Constants.RESPONSE_KEY_NON_APAR_COUNT, 0);
+        response.getResult().put(Constants.RESPONSE_KEY_APAR_CONTENT_LIST, new LinkedHashMap<>());
+        response.getResult().put(Constants.RESPONSE_KEY_NON_APAR_CONTENT_LIST, new LinkedHashMap<>());
+        response.setParams(new ApiRespParam());
+        response.getParams().setStatus(Constants.SUCCESS);
+        response.setResponseCode(HttpStatus.OK);
+    }
+
+    private void populateDictionaryResponse(ApiResponse response,
+                                            Map<String, List<CbPlanContentOccurrence>> aparContentMap,
+                                            Map<String, List<CbPlanContentOccurrence>> nonAparContentMap,
+                                            Map<String, Object> enrichedContentMap) {
+        response.getResult().put(Constants.RESPONSE_KEY_APAR_COUNT, aparContentMap.size());
+        response.getResult().put(Constants.RESPONSE_KEY_NON_APAR_COUNT, nonAparContentMap.size());
+        response.getResult().put(Constants.RESPONSE_KEY_APAR_CONTENT_LIST, aparContentMap);
+        response.getResult().put(Constants.RESPONSE_KEY_NON_APAR_CONTENT_LIST, nonAparContentMap);
+        if (Objects.nonNull(enrichedContentMap)) {
+            response.getResult().put(Constants.RESPONSE_KEY_ENRICHED_CONTENT_LIST, enrichedContentMap);
+        }
+        response.setParams(new ApiRespParam());
+        response.getParams().setStatus(Constants.SUCCESS);
+        response.setResponseCode(HttpStatus.OK);
+    }
+
+    /**
+     * Retrieves cached dictionary entry from Redis.
+     *
+     * @param redisCacheKey Redis cache key
+     * @return CbPlanDictionaryCacheEntry if cache hit, null otherwise
+     * @throws JsonProcessingException if deserialization fails
+     */
+    private CbPlanDictionaryCacheEntry getCachedDictionaryEntry(String redisCacheKey) throws JsonProcessingException {
+        String cachedResult = redisCacheMgr.getFromCache(redisCacheKey);
+        if (StringUtils.isBlank(cachedResult)) {
+            return null;
+        }
+        return mapper.readValue(cachedResult, CbPlanDictionaryCacheEntry.class);
+    }
+
+    /**
+     * Computes dictionary grouping from CB Plans (cache miss path).
+     *
+     * @param userId        user ID
+     * @param userOrgId     user's organization ID
+     * @param planYear      plan year
+     * @param redisCacheKey Redis cache key for caching result
+     * @param response      API response for error reporting
+     * @return CbPlanDictionaryCacheEntry with computed grouping, or null if no plans found
+     * @throws JsonProcessingException if serialization fails
+     */
+    private CbPlanDictionaryCacheEntry computeDictionaryFromPlans(String userId, String userOrgId, String planYear,
+                                                                  String redisCacheKey, ApiResponse response)
+            throws JsonProcessingException {
+        AtomicBoolean isCacheEnabled = new AtomicBoolean(false);
+        List<Map<String, Object>> activeCbPlans = cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(
+                userOrgId, planYear, isCacheEnabled);
+        if (CollectionUtils.isEmpty(activeCbPlans)) {
+            return cacheEmptyDictionary(userId, planYear, redisCacheKey);
+        }
+        Map<String, String> userProfile = buildUserProfile(userId, response);
+        if (userProfile.isEmpty()) {
+            return null;
+        }
+        return processPlanGroupingAndCache(activeCbPlans, userProfile, userOrgId, userId, planYear,
+                redisCacheKey, isCacheEnabled.get());
+    }
+
+    /**
+     * Caches empty dictionary entry when no plans found.
+     *
+     * @param userId        user ID
+     * @param planYear      plan year
+     * @param redisCacheKey Redis cache key
+     * @return empty CbPlanDictionaryCacheEntry
+     * @throws JsonProcessingException if serialization fails
+     */
+    private CbPlanDictionaryCacheEntry cacheEmptyDictionary(String userId, String planYear, String redisCacheKey)
+            throws JsonProcessingException {
+        log.info("cacheEmptyDictionary: No active plans found - userId={}, planYear={}", userId, planYear);
+        CbPlanDictionaryCacheEntry emptyEntry = new CbPlanDictionaryCacheEntry(
+                new LinkedHashMap<>(), new LinkedHashMap<>(), 0, 0);
+        redisCacheMgr.putInCache(redisCacheKey, mapper.writeValueAsString(emptyEntry),
+                serverProperties.getCbPlanV3RedisCacheTtlSeconds());
+        return emptyEntry;
+    }
+
+    /**
+     * Processes plan grouping and caches result.
+     *
+     * @param activeCbPlans  CB Plans to process
+     * @param userProfile    user profile
+     * @param userOrgId      user's organization ID
+     * @param userId         user ID
+     * @param planYear       plan year
+     * @param redisCacheKey  Redis cache key
+     * @param isCacheEnabled whether caching is enabled
+     * @return CbPlanDictionaryCacheEntry with computed grouping
+     * @throws JsonProcessingException if serialization fails
+     */
+    private CbPlanDictionaryCacheEntry processPlanGroupingAndCache(List<Map<String, Object>> activeCbPlans,
+                                                                   Map<String, String> userProfile, String userOrgId,
+                                                                   String userId, String planYear, String redisCacheKey,
+                                                                   boolean isCacheEnabled) throws JsonProcessingException {
+        Map<String, List<CbPlanContentOccurrence>> aparContentMap = new LinkedHashMap<>();
+        Map<String, List<CbPlanContentOccurrence>> nonAparContentMap = new LinkedHashMap<>();
+        Set<String> aparContentIds = new HashSet<>();
+        List<String> plansToCache = new ArrayList<>();
+        processPlansForDictionary(activeCbPlans, userProfile, userOrgId,
+                aparContentMap, nonAparContentMap, aparContentIds, plansToCache);
+        CbPlanDictionaryCacheEntry cacheEntry = new CbPlanDictionaryCacheEntry(
+                aparContentMap, nonAparContentMap, aparContentMap.size(), nonAparContentMap.size());
+        if (isCacheEnabled && CollectionUtils.isNotEmpty(plansToCache)) {
+            redisCacheMgr.putInCache(redisCacheKey, mapper.writeValueAsString(cacheEntry),
+                    serverProperties.getCbPlanV3RedisCacheTtlSeconds());
+            log.info("processPlanGroupingAndCache: Cached grouping - userId={}, planYear={}, aparCount={}, nonAparCount={}",
+                    userId, planYear, aparContentMap.size(), nonAparContentMap.size());
+        }
+        return cacheEntry;
+    }
+
+    /**
+     * Enriches content metadata and populates final response.
+     *
+     * @param response            API response
+     * @param cacheEntry          cache entry with grouping data
+     * @param isEnrichmentEnabled whether enrichment is requested
+     */
+    private void enrichAndPopulateResponse(ApiResponse response, CbPlanDictionaryCacheEntry cacheEntry,
+                                           boolean isEnrichmentEnabled) {
+        Map<String, Object> enrichedContentMap = null;
+        if (isEnrichmentEnabled) {
+            log.debug("enrichAndPopulateResponse: Enriching content metadata - contentCount={}",
+                    cacheEntry.getAparCount() + cacheEntry.getNonAparCount());
+            enrichedContentMap = enrichContentList(cacheEntry.getAparContentList(), cacheEntry.getNonAparContentList());
+        }
+        populateDictionaryResponse(response, cacheEntry.getAparContentList(),
+                cacheEntry.getNonAparContentList(), enrichedContentMap);
+    }
+
+    /**
+     * Reads a CB Plan by ID with enriched content details.
+     * Queries cb_plan_v3 table and enriches the response with content metadata.
+     *
+     * @param cbPlanId      the CB Plan ID to retrieve
+     * @param userOrgId     the organization ID of the user
+     * @param authUserToken the authentication token
+     * @return ApiResponse containing the CB Plan details or error
+     */
+    @Override
+    public ApiResponse readCbPlan(String cbPlanId, String userOrgId, String authUserToken) {
+        ApiResponse response = ProjectUtil.createDefaultResponse(Constants.API_CB_PLAN_V3_READ_BY_ID);
+        log.info("readCbPlan: Starting - cbPlanId={}, userOrgId={}", cbPlanId, userOrgId);
+
+        try {
+            if (StringUtils.isEmpty(cbPlanId)) {
+                log.warn("readCbPlan: Missing cbPlanId");
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr("CbPlanId is missing.");
+                response.setResponseCode(HttpStatus.BAD_REQUEST);
+                return response;
+            }
+
+            Map<String, Object> queryFilter = new HashMap<>();
+            queryFilter.put(Constants.PLAN_ID, cbPlanId);
+            List<Map<String, Object>> cbPlanList = cassandraOperation.getRecordsByProperties(
+                    Constants.KEYSPACE_SUNBIRD, Constants.TABLE_CB_PLAN_V3, queryFilter, null,
+                    serverProperties.getCassandraQueryLimitPrimaryKey());
+
+            if (CollectionUtils.isEmpty(cbPlanList)) {
+                log.warn("readCbPlan: CB Plan not found - cbPlanId={}", cbPlanId);
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr("CbPlan does not exist for ID: " + cbPlanId);
+                response.setResponseCode(HttpStatus.BAD_REQUEST);
+                return response;
+            }
+
+            Map<String, Object> cbPlan = cbPlanList.get(0);
+            CbPlanReadResponseDto enrichedData = buildEnrichedPlanData(cbPlan, cbPlanId);
+            response.getResult().put(Constants.CONTENT, enrichedData);
+            log.info("readCbPlan: Successfully retrieved CB Plan - cbPlanId={}, planYear={}",
+                    cbPlanId, enrichedData.getPlanYear());
+
+        } catch (JsonProcessingException e) {
+            log.error("readCbPlan: JSON processing failed - cbPlanId={}", cbPlanId, e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr("Failed to process plan data");
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error("readCbPlan: Failed to read CB Plan - cbPlanId={}, userOrgId={}", cbPlanId, userOrgId, e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(e.getMessage());
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return response;
+    }
+
+    /**
+     * Builds enriched CB Plan data from raw Cassandra record.
+     * Extracts plan details from either draftData (for LIVE plans with draft)
+     * or direct fields, and enriches content list.
+     *
+     * @param cbPlan   raw CB Plan record from Cassandra
+     * @param cbPlanId CB Plan ID
+     * @return enriched plan data DTO
+     * @throws JsonProcessingException if JSON parsing fails
+     */
+    private CbPlanReadResponseDto buildEnrichedPlanData(Map<String, Object> cbPlan, String cbPlanId)
+            throws JsonProcessingException {
+        String draftData = (String) cbPlan.get(Constants.DRAFT_DATA);
+        String status = (String) cbPlan.get(Constants.STATUS);
+        boolean hasDraftData = StringUtils.isNotBlank(draftData) && !Constants.EMPTY_JSON.equals(draftData);
+        boolean isLiveStatus = Constants.LIVE.equalsIgnoreCase(status);
+
+        String name;
+        Instant endDate;
+        Boolean isApar;
+        List<String> contentIdList;
+
+        if (hasDraftData && isLiveStatus) {
+            CbPlanDto cbPlanDto = mapper.readValue(draftData, CbPlanDto.class);
+            name = cbPlanDto.getName();
+            endDate = cbPlanDto.getEndDate() != null ? cbPlanDto.getEndDate().toInstant() : null;
+            isApar = cbPlanDto.getIsApar() != null && cbPlanDto.getIsApar();
+            contentIdList = cbPlanDto.getContentList();
+        } else {
+            name = (String) cbPlan.get(Constants.NAME);
+            endDate = (Instant) cbPlan.get(Constants.END_DATE_REQUEST);
+            isApar = (Boolean) cbPlan.getOrDefault(Constants.IS_APAR, false);
+            contentIdList = extractContentList(cbPlan.get(Constants.CONTENT_LIST));
+        }
+
+        return CbPlanReadResponseDto.builder()
+                .id(cbPlanId)
+                .name(name)
+                .planYear((String) cbPlan.get(Constants.PLAN_YEAR))
+                .endDate(endDate)
+                .isApar(isApar)
+                .contentType((String) cbPlan.get(Constants.CONTENT_TYPE))
+                .planType((String) cbPlan.get(Constants.PLAN_TYPE))
+                .createdAt((Instant) cbPlan.get(Constants.CREATED_AT_REQ))
+                .cbPublishedAt((Instant) cbPlan.get(Constants.CB_PUBLISHED_AT))
+                .status(status)
+                .createdBy((String) cbPlan.get(Constants.CREATED_BY))
+                .createdByName(StringUtils.EMPTY)
+                .contextData(parseContextDataToJsonNode(cbPlan.get(Constants.CONTEXT_DATA_REQUEST)))
+                .contentList(contentService.enrichContentInfoForCBPlan(contentIdList))
+                .build();
+    }
+
+    /**
+     * Extracts content ID list from Cassandra object.
+     * Handles type conversion safely to avoid unchecked cast warnings.
+     *
+     * @param contentListObj raw content list object from Cassandra
+     * @return list of content IDs, or empty list if null/invalid
+     */
+    private List<String> extractContentList(Object contentListObj) {
+        if (contentListObj == null) {
+            return new ArrayList<>();
+        }
+        try {
+            return (List<String>) contentListObj;
+        } catch (ClassCastException e) {
+            log.warn("extractContentList: Invalid content list type, returning empty list", e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Parses context data from Cassandra object to JsonNode.
+     * Handles JSON parsing and returns null if parsing fails.
+     *
+     * @param contextData raw context data from Cassandra
+     * @return JsonNode representation or null if parsing fails
+     */
+    private JsonNode parseContextDataToJsonNode(Object contextData) {
+        if (contextData == null) {
+            return null;
+        }
+
+        try {
+            return mapper.readTree(contextData.toString());
+        } catch (JsonProcessingException e) {
+            log.warn("parseContextDataToJsonNode: Failed to parse contextData, returning null", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanValidationServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanValidationServiceV3Impl.java
@@ -1,0 +1,255 @@
+package com.igot.cb.cbplan.service.impl;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.service.UserAndOrgServiceImpl;
+import com.igot.cb.util.AccessTokenValidator;
+import com.igot.cb.util.Constants;
+import com.igot.cb.util.RequestValidator;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service for CB Plan validation operations.
+ *
+ * @version 3.0
+ */
+@Service
+@Slf4j
+public class CbPlanValidationServiceV3Impl {
+    private final AccessTokenValidator accessTokenValidator;
+    private final UserAndOrgServiceImpl userAndOrgService;
+    private final RequestValidator requestValidator;
+    private final ObjectMapper mapper;
+
+    public CbPlanValidationServiceV3Impl(AccessTokenValidator accessTokenValidator,
+                                         UserAndOrgServiceImpl userAndOrgService,
+                                         RequestValidator requestValidator) {
+        this.accessTokenValidator = accessTokenValidator;
+        this.userAndOrgService = userAndOrgService;
+        this.requestValidator = requestValidator;
+        this.mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    /**
+     * Validates authentication token and extracts user ID.
+     *
+     * @param authToken authentication token
+     * @param response  API response object
+     * @return user ID or null if validation fails
+     */
+    public String validateAndExtractUserId(String authToken, ApiResponse response) {
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(authToken, response);
+        if (StringUtils.isEmpty(userId)) {
+            log.warn("CbPlanValidationService: {}", Constants.ERR_FAILED_TO_EXTRACT_USER_ID);
+            return null;
+        }
+        return userId;
+    }
+
+    /**
+     * Validates user organization and returns root org ID.
+     *
+     * @param userId   user ID
+     * @param response API response object
+     * @return root org ID or null if validation fails
+     */
+    public String validateUserOrganization(String userId, ApiResponse response) {
+        String rootOrgId = getRootOrgFromUser(userId, response);
+        if (Constants.FAILED.equalsIgnoreCase(response.getParams().getStatus())) {
+            return null;
+        }
+        return rootOrgId;
+    }
+
+    /**
+     * Validates if organization is CCA.
+     *
+     * @param rootOrgId root organization ID
+     * @param response  API response object
+     * @return true if CCA, false otherwise
+     */
+    public boolean validateOrgCCA(String rootOrgId, ApiResponse response) {
+        return getCCAFromOrg(rootOrgId, response);
+    }
+
+    /**
+     * Validates CB Plan create request.
+     *
+     * @param request   API request
+     * @param isCCA     whether org is CCA
+     * @param userOrgId user org ID
+     * @param response  API response object
+     * @return true if valid, false otherwise
+     */
+    public boolean validateRequest(ApiRequest request, boolean isCCA, String userOrgId, ApiResponse response) {
+        try {
+            List<String> validations = requestValidator.validateCbPlanCreateRequest(request, isCCA, userOrgId, false);
+            if (CollectionUtils.isNotEmpty(validations)) {
+                response.getParams().setStatus(Constants.FAILED);
+                response.getParams().setErr(mapper.writeValueAsString(validations));
+                response.setResponseCode(HttpStatus.BAD_REQUEST);
+                log.warn("CbPlanValidationService: Validation failed for orgId: {}", userOrgId);
+                return false;
+            }
+            return true;
+        } catch (JsonProcessingException e) {
+            log.error("CbPlanValidationService: {}", Constants.ERR_FAILED_TO_SERIALIZE_VALIDATION, e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(Constants.ERR_VALIDATION_ERROR);
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return false;
+        }
+    }
+
+    /**
+     * Validates if plan ID exists in request.
+     *
+     * @param request  API request
+     * @param response API response object
+     * @return true if plan ID exists, false otherwise
+     */
+    public boolean validatePlanIdExists(ApiRequest request, ApiResponse response) {
+        Map<String, Object> updatedCbPlan = (Map<String, Object>) request.getRequest();
+        String cbPlanId = (String) updatedCbPlan.get(Constants.ID);
+        if (StringUtils.isBlank(cbPlanId)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(Constants.ERR_REQUIRED_PARAM_ID_MISSING);
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Checks if user is unauthorized to update CB Plan.
+     *
+     * @param userId         user ID
+     * @param existingCbPlan existing CB Plan data
+     * @param userRoles      user roles
+     * @param response       API response object
+     * @return true if unauthorized, false if authorized
+     */
+    public boolean isUnauthorizedToUpdate(String userId, Map<String, Object> existingCbPlan,
+                                          List<String> userRoles, ApiResponse response) {
+        String createdBy = (String) existingCbPlan.get(Constants.CREATED_BY);
+        boolean isOwner = userId.equals(createdBy);
+        boolean isAdmin = CollectionUtils.isNotEmpty(userRoles) && userRoles.contains(Constants.ROLE_ADMIN);
+        if (!isOwner && !isAdmin) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(Constants.ERR_UNAUTHORIZED_UPDATE);
+            response.setResponseCode(HttpStatus.FORBIDDEN);
+            log.warn("CbPlanValidationService: User {} unauthorized to update plan created by {}", userId, createdBy);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Validates context data for LIVE plan updates.
+     *
+     * @param incomingRequest         incoming request map
+     * @param isCCA                   whether org is CCA
+     * @param rootOrgId               root org ID
+     * @param rootOrgIdsInContextData set to populate with org IDs from context
+     * @param response                API response object
+     * @return true if valid, false otherwise
+     */
+    public boolean validateContextDataForLivePlan(Map<String, Object> incomingRequest, boolean isCCA,
+                                                  String rootOrgId, java.util.Set<String> rootOrgIdsInContextData,
+                                                  ApiResponse response) {
+        List<String> errors = requestValidator.validateContextData(incomingRequest, isCCA, rootOrgId,
+                rootOrgIdsInContextData);
+        if (CollectionUtils.isNotEmpty(errors)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(Constants.ERR_VALIDATION_ERRORS + String.join("; ", errors));
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validates plan ID from request map.
+     *
+     * @param incomingRequest incoming request map
+     * @param response        API response object
+     * @return plan ID or null if validation fails
+     */
+    public String validateAndExtractPlanId(Map<String, Object> incomingRequest, ApiResponse response) {
+        String planId = (String) incomingRequest.get(Constants.ID);
+        if (StringUtils.isBlank(planId)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(Constants.ERR_REQUIRED_PARAM_ID_MISSING);
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            return null;
+        }
+        return planId;
+    }
+
+    /**
+     * Checks if CB Plan is already archived.
+     *
+     * @param existingCbPlan existing CB Plan data
+     * @param cbPlanId       CB Plan ID
+     * @param response       API response object
+     * @return true if already archived, false otherwise
+     */
+    public boolean isAlreadyArchived(Map<String, Object> existingCbPlan, String cbPlanId, ApiResponse response) {
+        String status = (String) existingCbPlan.get(Constants.STATUS);
+        if (Constants.CB_RETIRE.equalsIgnoreCase(status)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErr(String.format(Constants.ERR_CB_PLAN_ALREADY_RETIRED, cbPlanId));
+            response.setResponseCode(HttpStatus.BAD_REQUEST);
+            log.warn("CbPlanValidationService: CB Plan {} is already retired", cbPlanId);
+            return true;
+        }
+        return false;
+    }
+
+    private String getRootOrgFromUser(String userId, ApiResponse response) {
+        Map<String, Object> userMap = userAndOrgService.readUserProfileFromDB(
+                userId,
+                Arrays.asList(Constants.ID, Constants.ROOT_ORG_ID));
+        if (MapUtils.isEmpty(userMap)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErrMsg(Constants.ERR_FAILED_TO_READ_USER_DETAILS + userId);
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+            log.error("CbPlanValidationService.getRootOrgFromUser: User not found for userId: {}", userId);
+            return null;
+        }
+        return (String) userMap.get(Constants.ROOT_ORG_ID);
+    }
+
+    private boolean getCCAFromOrg(String orgId, ApiResponse response) {
+        Map<String, Object> orgMap = userAndOrgService.readOrgFromDB(orgId, null);
+        if (MapUtils.isEmpty(orgMap)) {
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErrMsg(Constants.ERR_FAILED_TO_READ_ORG_DETAILS + orgId);
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+            log.error("CbPlanValidationService.getCCAFromOrg: Org not found for orgId: {}", orgId);
+            return false;
+        }
+        if (orgMap.containsKey(Constants.IS_CCA) && Objects.nonNull(orgMap.get(Constants.IS_CCA))) {
+            return Boolean.parseBoolean(orgMap.get(Constants.IS_CCA).toString());
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/igot/cb/cbplan/util/CbPlanYearUtil.java
+++ b/src/main/java/com/igot/cb/cbplan/util/CbPlanYearUtil.java
@@ -1,0 +1,101 @@
+package com.igot.cb.cbplan.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class for CB Plan year operations (financial year resolution and validation).
+ *
+ * @version 3.0
+ */
+@Slf4j
+public final class CbPlanYearUtil {
+    private static final Pattern PLAN_YEAR_PATTERN = Pattern.compile("^\\d{4}-\\d{2}$");
+    private static final Month FY_START_MONTH = Month.APRIL;
+
+    private CbPlanYearUtil() {
+    }
+
+    /**
+     * Resolves the current financial year based on Indian FY cycle (April 1 - March 31).
+     * Examples:
+     * - Date: 2026-08-12 → Returns "2026-27"
+     * - Date: 2026-02-12 → Returns "2025-26"
+     * - Date: 2026-04-01 → Returns "2026-27"
+     * - Date: 2026-03-31 → Returns "2025-26"
+     *
+     * @return current financial year in format "YYYY-YY"
+     */
+    public static String resolveCurrentFinancialYear() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Kolkata"));
+        return resolveFinancialYearForDate(today);
+    }
+
+    /**
+     * Resolves the financial year for a specific date.
+     *
+     * @param date the date to resolve FY for
+     * @return financial year in format "YYYY-YY"
+     */
+    public static String resolveFinancialYearForDate(LocalDate date) {
+        int year = date.getYear();
+        Month month = date.getMonth();
+        if (month.getValue() >= FY_START_MONTH.getValue()) {
+            int nextYear = year + 1;
+            return String.format("%d-%02d", year, nextYear % 100);
+        } else {
+            int prevYear = year - 1;
+            return String.format("%d-%02d", prevYear, year % 100);
+        }
+    }
+
+    /**
+     * Validates plan year format (YYYY-YY).
+     * Expected format: 4-digit year, hyphen, 2-digit year suffix.
+     * Examples: "2026-27", "2025-26"
+     *
+     * @param planYear the plan year string to validate
+     * @return true if valid format, false otherwise
+     */
+    public static boolean isValidPlanYearFormat(String planYear) {
+        if (planYear == null || planYear.isBlank()) {
+            return false;
+        }
+        if (!PLAN_YEAR_PATTERN.matcher(planYear.trim()).matches()) {
+            return false;
+        }
+        try {
+            String[] parts = planYear.trim().split("-");
+            int startYear = Integer.parseInt(parts[0]);
+            int endYearSuffix = Integer.parseInt(parts[1]);
+            int expectedEndYearSuffix = (startYear + 1) % 100;
+            if (endYearSuffix != expectedEndYearSuffix) {
+                log.warn("Invalid plan year: {} - end year suffix should be {}", planYear, expectedEndYearSuffix);
+                return false;
+            }
+            return true;
+        } catch (NumberFormatException e) {
+            log.error("Failed to parse plan year: {}", planYear, e);
+            return false;
+        }
+    }
+
+    /**
+     * Validates and normalizes plan year string.
+     * Returns trimmed plan year if valid, null otherwise.
+     *
+     * @param planYear the plan year to validate
+     * @return trimmed plan year if valid, null otherwise
+     */
+    public static String validateAndNormalize(String planYear) {
+        if (planYear == null || planYear.isBlank()) {
+            return null;
+        }
+        String normalized = planYear.trim();
+        return isValidPlanYearFormat(normalized) ? normalized : null;
+    }
+}

--- a/src/main/java/com/igot/cb/util/CbExtServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbExtServerProperties.java
@@ -130,4 +130,28 @@ public class CbExtServerProperties {
     @Value("${external.training.batch.size}")
     private int externalTrainingBatchSize;
 
+    @Value("${cbplan.enriched.content.fields}")
+    private String cbPlanEnrichedContentFields;
+
+    @Value("${cb.plan.v3.batch.size}")
+    private int cbPlanV3BatchSize;
+
+    @Value("${cb.plan.v3.cache.ttl.minutes}")
+    private int cbPlanV3CacheTtlMinutes;
+
+    @Value("${cb.plan.v3.caffine.cache.max.size}")
+    private int cbPlanV3CaffineCacheMaxSize;
+
+    @Value("${cb.plan.v3.redis.cache.ttl.seconds}")
+    private int cbPlanV3RedisCacheTtlSeconds;
+
+    @Value("${cassandra.query.limit.primary.key}")
+    private int cassandraQueryLimitPrimaryKey;
+
+    @Value("${cassandra.query.limit.user.extended.profile}")
+    private int cassandraQueryLimitUserExtendedProfile;
+
+    public List<String> getCbPlanEnrichedContentFieldsList() {
+        return Arrays.asList(cbPlanEnrichedContentFields.split(",", -1));
+    }
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -620,6 +620,54 @@ public class Constants {
     public static final String COURSE_CATEGORY_INVITE_ONLY_ASSESSMENT = "Invite-Only Assessment";
     public static final String BATCH_END_DATE   = "batchEndDate";
 
+    public static final String ERR_CANNOT_CHANGE_ISAPAR = "Cannot change isApar from true to false.";
+    public static final String ERR_FIELD_CANNOT_BE_NULL = "Field '%s' cannot be null.";
+    public static final String ERR_VALIDATION_ERRORS = "Validation errors: ";
+    public static final String ERR_FAILED_TO_UPDATE_CB_PLAN = "Failed to Update CB Plan for OrgId: ";
+    public static final String ERR_PROCESSING_CB_PLAN_DATA = "Error processing existing CB Plan data";
+    public static final String ERR_SERIALIZING_CB_PLAN = "Error serializing existing CB Plan for draft storage";
+    public static final String MSG_UPDATED_AS_DRAFT = "Updated cbPlan as draft for cbPlanId: %s. Publish to make it live.";
+    public static final String TABLE_CB_PLAN_V3 = "cb_plan_v3";
+    public static final String TABLE_CB_PLAN_V3_LOOKUP_BY_ORG = "cb_plan_v3_lookup_by_org";
+    public static final String TABLE_CB_PLAN_V3_LOOKUP_BY_ALL_ORG = "cb_plan_v3_lookup_by_all_org";
+    public static final String TABLE_CB_PLAN_V3_CONTENT_LOOKUP = "cb_plan_v3_content_lookup";
+    public static final String ERR_UNAUTHORIZED_UPDATE = "User is not authorized to update this CB Plan";
+    public static final String ERR_CB_PLAN_ALREADY_RETIRED = "CB Plan %s is already retired";
+    public static final String ROLE_ADMIN = "ADMIN";
+    public static final String RESULT_DELETED = "deleted";
+    public static final String RESULT_UPDATED = "updated";
+    public static final String RESULT_SKIPPED = "skipped";
+    public static final String EXTENDED_CONTENT_READ_END_POINT = "extended-content-read-endpoint";
+    public static final String EXISTING_ROOT_ORG_IDS = "existingRootOrgIds";
+    public static final String NEW_ROOT_ORG_IDS = "newRootOrgIds";
+    public static final String EXTENDED_READ_CONTENT_CACHE_KEY_PREFIX = "extended_read_content_";
+    public static final String EXTERNAL_CONTENT_PREFIX = "ext_";
+    public static final String CONTENT_ID_COLUMN = "contentid";
+    public static final String PLAN_ID_COLUMN = "planid";
+    public static final String DATE_FORMAT_YYYY_MM_DD = "yyyy-MM-dd";
+    public static final String TIMEZONE_ASIA_KOLKATA = "Asia/Kolkata";
+    public static final String ERR_FAILED_TO_EXTRACT_USER_ID = "Failed to extract userId from token";
+    public static final String ERR_FAILED_TO_READ_USER_DETAILS = "Failed to read user details from DB. UserId: ";
+    public static final String ERR_FAILED_TO_READ_ORG_DETAILS = "Failed to read org details from DB. OrgId: ";
+    public static final String ERR_FAILED_TO_CREATE_CB_PLAN = "Failed to Create CB Plan for OrgId: ";
+    public static final String ERR_MESSAGE_SEPARATOR = " message: ";
+    public static final String ERR_VALIDATION_ERROR = "Validation error";
+    public static final String ERR_INVALID_END_DATE_FORMAT = "Invalid endDate format: ";
+    public static final String ERR_FAILED_TO_SERIALIZE_VALIDATION = "Failed to serialize validation errors";
+    public static final String ERR_REQUIRED_PARAM_ID_MISSING = "Required Param id is missing";
+    public static final String ERR_CB_PLAN_NOT_FOUND = "cbPlan is not found for id: ";
+    public static final String API_CB_PLAN_V3_READ_BY_ID = "api.cb.plan.v3.read.byId";
+    public static final String API_CBPLAN_V3_GET_USER_DICTIONARY = "api.cbplan.v3.user.list";
+    public static final String REQUEST_PARAM_PLAN_YEAR = "planYear";
+    public static final String REQUEST_PARAM_ENRICHMENT = "enrichment";
+    public static final String RESPONSE_KEY_APAR_COUNT = "aparCount";
+    public static final String RESPONSE_KEY_NON_APAR_COUNT = "nonAparCount";
+    public static final String RESPONSE_KEY_APAR_CONTENT_LIST = "aparContentList";
+    public static final String RESPONSE_KEY_NON_APAR_CONTENT_LIST = "nonAparContentList";
+    public static final String RESPONSE_KEY_ENRICHED_CONTENT_LIST = "enrichedContentList";
+    public static final String SECURE_CONTENT_SUFFIX = "_rc";
+    public static final String CACHE_FLAG_FROM_CACHE = "_fromCache";
+    public static final String EMPTY_JSON = "{}";
     private Constants() {
     }
 }

--- a/src/main/resources/EsRequiredFields/EsRequiredFieldsCbPlan.json
+++ b/src/main/resources/EsRequiredFields/EsRequiredFieldsCbPlan.json
@@ -106,5 +106,13 @@
         "type": "date"
       }
     }
+  },
+  "planYear": {
+    "type": "text",
+    "fields": {
+      "keyword": {
+        "type": "keyword"
+      }
+    }
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -152,3 +152,13 @@ enrolment.dictionary.url=/v1/user/enrol/dictionary
 lms.host=http://lms-service:9000
 standalone.assessment.search.request={"request":{"limit":500,"query":"","fields":["identifier"],"filters":{"contentType":["Course"],"courseCategory":"Invite-Only Assessment","primaryCategory":["Standalone Assessment"]},"sort_by":{"lastUpdatedOn":"desc"}}}
 lms.enrollment.details.url=/v3/user/enrol/courses/details
+
+cbplan.enriched.content.fields=identifier,name,description,contentType,duration,primaryCategory,status,createdOn,lastUpdatedOn
+cb.plan.v3.batch.size=5
+cb.plan.v3.cache.ttl.minutes=60
+cb.plan.v3.caffine.cache.max.size=5000
+cb.plan.v3.redis.cache.ttl.seconds=3600
+
+# Cassandra Query Limits
+cassandra.query.limit.primary.key=1
+cassandra.query.limit.user.extended.profile=10000

--- a/src/test/java/com/igot/cb/cache/CbPlanCacheMgrV3Test.java
+++ b/src/test/java/com/igot/cb/cache/CbPlanCacheMgrV3Test.java
@@ -1,0 +1,351 @@
+package com.igot.cb.cache;
+
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.util.Constants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanCacheMgrV3Test {
+
+    private static final String ORG_ID = "org1";
+    private static final String PLAN_YEAR = "2026-27";
+    private static final int BATCH_SIZE = 2;
+
+    @Mock
+    private CassandraOperation cassandraOperation;
+
+    @InjectMocks
+    private CbPlanCacheMgrV3 cbPlanCacheMgrV3;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(cbPlanCacheMgrV3, "ttlMinutes", 60);
+        ReflectionTestUtils.setField(cbPlanCacheMgrV3, "planBatchSize", BATCH_SIZE);
+        ReflectionTestUtils.setField(cbPlanCacheMgrV3, "maxCacheSize", 5000);
+        cbPlanCacheMgrV3.initCache();
+    }
+
+    private static Map<String, Object> lookupEntry(String planId, boolean isActive, Instant endDate) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put(Constants.PLAN_ID, planId);
+        entry.put(Constants.IS_ACTIVE, isActive);
+        entry.put(Constants.END_DATE_REQUEST, endDate);
+        return entry;
+    }
+
+    private static Map<String, Object> fullPlan(String planId, String status) {
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.PLAN_ID, planId);
+        plan.put(Constants.STATUS, status);
+        return plan;
+    }
+
+    private void stubAllOrgLookup(List<Map<String, Object>> rows) {
+        when(cassandraOperation.getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ALL_ORG), anyMap(), any(), any())).thenReturn(rows);
+    }
+
+    private void stubOrgLookup(List<Map<String, Object>> rows) {
+        when(cassandraOperation.getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ORG), anyMap(), any(), any())).thenReturn(rows);
+    }
+
+    private void stubFullPlanFetch(List<Map<String, Object>> rows) {
+        when(cassandraOperation.getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3), anyMap(), any(), any())).thenReturn(rows);
+    }
+
+    @Test
+    void testInitCacheCreatesBothCaches() {
+        assertNotNull(ReflectionTestUtils.getField(cbPlanCacheMgrV3, "cbPlanCache"));
+        assertNotNull(ReflectionTestUtils.getField(cbPlanCacheMgrV3, "planIdCache"));
+    }
+
+    // ---------------- getCbPlanForAllOrgs ----------------
+
+    @Test
+    void testGetCbPlanForAllOrgsLoadsFromCassandraOnMiss() {
+        stubAllOrgLookup(List.of(lookupEntry("plan1", true, Instant.EPOCH)));
+        List<Map<String, Object>> result = cbPlanCacheMgrV3.getCbPlanForAllOrgs(PLAN_YEAR);
+        assertEquals(1, result.size());
+        assertEquals("plan1", result.get(0).get(Constants.PLAN_ID));
+    }
+
+    @Test
+    void testGetCbPlanForAllOrgsFiltersInactiveEntries() {
+        stubAllOrgLookup(List.of(
+                lookupEntry("plan1", true, Instant.EPOCH),
+                lookupEntry("plan2", false, Instant.EPOCH)));
+        List<Map<String, Object>> result = cbPlanCacheMgrV3.getCbPlanForAllOrgs(PLAN_YEAR);
+        assertEquals(1, result.size());
+        assertEquals("plan1", result.get(0).get(Constants.PLAN_ID));
+    }
+
+    @Test
+    void testGetCbPlanForAllOrgsServesSecondCallFromCache() {
+        stubAllOrgLookup(List.of(lookupEntry("plan1", true, Instant.EPOCH)));
+        cbPlanCacheMgrV3.getCbPlanForAllOrgs(PLAN_YEAR);
+        List<Map<String, Object>> second = cbPlanCacheMgrV3.getCbPlanForAllOrgs(PLAN_YEAR);
+        assertEquals(1, second.size());
+        verify(cassandraOperation, times(1)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ALL_ORG), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlanForAllOrgsCachesPerPlanYear() {
+        stubAllOrgLookup(List.of(lookupEntry("plan1", true, Instant.EPOCH)));
+        cbPlanCacheMgrV3.getCbPlanForAllOrgs(PLAN_YEAR);
+        cbPlanCacheMgrV3.getCbPlanForAllOrgs("2025-26");
+        verify(cassandraOperation, times(2)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ALL_ORG), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlanForAllOrgsReturnsEmptyWhenCassandraReturnsNull() {
+        stubAllOrgLookup(null);
+        assertTrue(cbPlanCacheMgrV3.getCbPlanForAllOrgs(PLAN_YEAR).isEmpty());
+    }
+
+    // ---------------- getCbPlanForOrgId ----------------
+
+    @Test
+    void testGetCbPlanForOrgIdLoadsFromCassandraOnMiss() {
+        stubOrgLookup(List.of(lookupEntry("plan1", true, Instant.EPOCH)));
+        List<Map<String, Object>> result = cbPlanCacheMgrV3.getCbPlanForOrgId(ORG_ID, PLAN_YEAR);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testGetCbPlanForOrgIdFiltersInactiveEntries() {
+        stubOrgLookup(List.of(
+                lookupEntry("plan1", true, Instant.EPOCH),
+                lookupEntry("plan2", false, Instant.EPOCH)));
+        assertEquals(1, cbPlanCacheMgrV3.getCbPlanForOrgId(ORG_ID, PLAN_YEAR).size());
+    }
+
+    @Test
+    void testGetCbPlanForOrgIdServesSecondCallFromCache() {
+        stubOrgLookup(List.of(lookupEntry("plan1", true, Instant.EPOCH)));
+        cbPlanCacheMgrV3.getCbPlanForOrgId(ORG_ID, PLAN_YEAR);
+        cbPlanCacheMgrV3.getCbPlanForOrgId(ORG_ID, PLAN_YEAR);
+        verify(cassandraOperation, times(1)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ORG), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlanForOrgIdCachesPerOrg() {
+        stubOrgLookup(List.of(lookupEntry("plan1", true, Instant.EPOCH)));
+        cbPlanCacheMgrV3.getCbPlanForOrgId(ORG_ID, PLAN_YEAR);
+        cbPlanCacheMgrV3.getCbPlanForOrgId("org2", PLAN_YEAR);
+        verify(cassandraOperation, times(2)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ORG), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlanForOrgIdReturnsEmptyWhenCassandraReturnsNull() {
+        stubOrgLookup(null);
+        assertTrue(cbPlanCacheMgrV3.getCbPlanForOrgId(ORG_ID, PLAN_YEAR).isEmpty());
+    }
+
+    // ---------------- getCbPlanForAllAndOrgId ----------------
+
+    @Test
+    void testGetCbPlanForAllAndOrgIdCombinesOrgAndAllOrgPlans() {
+        stubOrgLookup(List.of(lookupEntry("plan1", true, Instant.parse("2026-12-31T00:00:00Z"))));
+        stubAllOrgLookup(List.of(lookupEntry("plan2", true, Instant.parse("2026-06-30T00:00:00Z"))));
+        stubFullPlanFetch(List.of(fullPlan("plan1", Constants.LIVE), fullPlan("plan2", Constants.LIVE)));
+        AtomicBoolean isCacheEnabled = new AtomicBoolean(false);
+        List<Map<String, Object>> result =
+                cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, isCacheEnabled);
+        assertEquals(2, result.size());
+        assertTrue(isCacheEnabled.get());
+    }
+
+    @Test
+    void testGetCbPlanForAllAndOrgIdKeepsOnlyLivePlans() {
+        stubOrgLookup(List.of(lookupEntry("plan1", true, Instant.EPOCH)));
+        stubAllOrgLookup(List.of());
+        stubFullPlanFetch(List.of(fullPlan("plan1", Constants.DRAFT)));
+        List<Map<String, Object>> result =
+                cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, new AtomicBoolean(false));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetCbPlanForAllAndOrgIdDeduplicatesByPlanId() {
+        Instant endDate = Instant.parse("2026-12-31T00:00:00Z");
+        stubOrgLookup(List.of(lookupEntry("plan1", true, endDate)));
+        stubAllOrgLookup(List.of(lookupEntry("plan1", true, endDate)));
+        stubFullPlanFetch(List.of(fullPlan("plan1", Constants.LIVE)));
+        List<Map<String, Object>> result =
+                cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, new AtomicBoolean(false));
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testGetCbPlanForAllAndOrgIdSkipsEntriesMissingEndDateOrPlanId() {
+        Map<String, Object> noEndDate = lookupEntry("plan1", true, null);
+        Map<String, Object> noPlanId = lookupEntry(null, true, Instant.EPOCH);
+        stubOrgLookup(List.of(noEndDate, noPlanId));
+        stubAllOrgLookup(List.of());
+        List<Map<String, Object>> result =
+                cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, new AtomicBoolean(false));
+        assertTrue(result.isEmpty());
+        verify(cassandraOperation, never()).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlanForAllAndOrgIdReturnsEmptyWhenNoPlansFound() {
+        stubOrgLookup(List.of());
+        stubAllOrgLookup(List.of());
+        AtomicBoolean isCacheEnabled = new AtomicBoolean(false);
+        List<Map<String, Object>> result =
+                cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, isCacheEnabled);
+        assertTrue(result.isEmpty());
+        assertFalse(isCacheEnabled.get());
+    }
+
+    @Test
+    void testGetCbPlanForAllAndOrgIdServesSecondCallFromCache() {
+        stubOrgLookup(List.of(lookupEntry("plan1", true, Instant.EPOCH)));
+        stubAllOrgLookup(List.of());
+        stubFullPlanFetch(List.of(fullPlan("plan1", Constants.LIVE)));
+        cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, new AtomicBoolean(false));
+        AtomicBoolean secondCallFlag = new AtomicBoolean(false);
+        List<Map<String, Object>> second =
+                cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, secondCallFlag);
+        assertEquals(1, second.size());
+        assertTrue(secondCallFlag.get());
+        verify(cassandraOperation, times(1)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ORG), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlanForAllAndOrgIdNeverServesEmptyResultFromItsOwnCache() {
+        stubOrgLookup(List.of());
+        stubAllOrgLookup(List.of());
+        AtomicBoolean firstCallFlag = new AtomicBoolean(false);
+        AtomicBoolean secondCallFlag = new AtomicBoolean(false);
+        cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, firstCallFlag);
+        List<Map<String, Object>> second =
+                cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(ORG_ID, PLAN_YEAR, secondCallFlag);
+        assertTrue(second.isEmpty());
+        assertFalse(firstCallFlag.get());
+        assertFalse(secondCallFlag.get());
+        verify(cassandraOperation, times(1)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ORG), anyMap(), any(), any());
+    }
+
+    // ---------------- getCbPlansByPlanIdsInBatch ----------------
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchReturnsEmptyForEmptyInput() {
+        assertTrue(cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of()).isEmpty());
+        verify(cassandraOperation, never()).getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchReturnsEmptyForNullInput() {
+        assertTrue(cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(null).isEmpty());
+    }
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchFetchesFromCassandra() {
+        stubFullPlanFetch(List.of(fullPlan("plan1", Constants.LIVE)));
+        List<Map<String, Object>> result = cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1"));
+        assertEquals(1, result.size());
+        assertEquals("plan1", result.get(0).get(Constants.PLAN_ID));
+    }
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchServesSecondCallFromPlanIdCache() {
+        stubFullPlanFetch(List.of(fullPlan("plan1", Constants.LIVE)));
+        cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1"));
+        List<Map<String, Object>> second = cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1"));
+        assertEquals(1, second.size());
+        verify(cassandraOperation, times(1)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchSplitsIntoConfiguredBatchSize() {
+        List<String> planIds = List.of("plan1", "plan2", "plan3", "plan4", "plan5");
+        when(cassandraOperation.getRecordsByProperties(anyString(), eq(Constants.TABLE_CB_PLAN_V3),
+                anyMap(), any(), any())).thenReturn(new ArrayList<>());
+        cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(planIds);
+        verify(cassandraOperation, times(3)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchMixesCachedAndFetchedPlans() {
+        stubFullPlanFetch(List.of(fullPlan("plan1", Constants.LIVE)));
+        cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1"));
+        when(cassandraOperation.getRecordsByProperties(anyString(), eq(Constants.TABLE_CB_PLAN_V3),
+                anyMap(), any(), any())).thenReturn(List.of(fullPlan("plan2", Constants.LIVE)));
+        List<Map<String, Object>> result = cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1", "plan2"));
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchSwallowsCassandraException() {
+        when(cassandraOperation.getRecordsByProperties(anyString(), eq(Constants.TABLE_CB_PLAN_V3),
+                anyMap(), any(), any())).thenThrow(new RuntimeException("cassandra down"));
+        assertTrue(cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1")).isEmpty());
+    }
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchContinuesAfterFailedBatch() {
+        when(cassandraOperation.getRecordsByProperties(anyString(), eq(Constants.TABLE_CB_PLAN_V3),
+                anyMap(), any(), any()))
+                .thenThrow(new RuntimeException("cassandra down"))
+                .thenReturn(List.of(fullPlan("plan3", Constants.LIVE)));
+        List<Map<String, Object>> result =
+                cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1", "plan2", "plan3"));
+        assertEquals(1, result.size());
+        assertEquals("plan3", result.get(0).get(Constants.PLAN_ID));
+    }
+
+    @Test
+    void testGetCbPlansByPlanIdsInBatchSkipsCachingEntriesWithoutPlanId() {
+        Map<String, Object> planWithoutId = new HashMap<>();
+        planWithoutId.put(Constants.STATUS, Constants.LIVE);
+        stubFullPlanFetch(List.of(planWithoutId));
+        cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1"));
+        cbPlanCacheMgrV3.getCbPlansByPlanIdsInBatch(List.of("plan1"));
+        verify(cassandraOperation, times(2)).getRecordsByProperties(anyString(),
+                eq(Constants.TABLE_CB_PLAN_V3), anyMap(), any(), any());
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanCacheMgrV3(cassandraOperation));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/controller/CbPlanWithAccessSettingsV3Test.java
+++ b/src/test/java/com/igot/cb/cbplan/controller/CbPlanWithAccessSettingsV3Test.java
@@ -1,0 +1,138 @@
+package com.igot.cb.cbplan.controller;
+
+import com.igot.cb.cbplan.service.CbPlanServiceV3;
+import com.igot.cb.elasticsearch.dto.SearchCriteria;
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanWithAccessSettingsV3Test {
+
+    private static final String TOKEN = "token";
+    private static final String ORG_ID = "orgId";
+    private static final String PLAN_ID = "plan123";
+
+    @Mock
+    private CbPlanServiceV3 cbPlanServiceV3;
+
+    @InjectMocks
+    private CbPlanWithAccessSettingsV3 controller;
+
+    private static ApiResponse successResponse() {
+        ApiResponse response = new ApiResponse();
+        response.getParams().setStatus(Constants.SUCCESS);
+        response.setResponseCode(HttpStatus.OK);
+        return response;
+    }
+
+    private static ApiRequest apiRequest() {
+        ApiRequest request = new ApiRequest();
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.ID, PLAN_ID);
+        request.setRequest(requestMap);
+        return request;
+    }
+
+    @Test
+    void testCreateCbPlan() {
+        ApiResponse mockResponse = successResponse();
+        mockResponse.setResponseCode(HttpStatus.CREATED);
+        when(cbPlanServiceV3.createCbPlan(any(), anyString(), anyString())).thenReturn(mockResponse);
+        ResponseEntity<ApiResponse> response = controller.createCbPlan(apiRequest(), TOKEN, ORG_ID);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(Constants.SUCCESS, response.getBody().getParams().getStatus());
+        verify(cbPlanServiceV3).createCbPlan(any(), eq(ORG_ID), eq(TOKEN));
+    }
+
+    @Test
+    void testUpdateCbPlan() {
+        when(cbPlanServiceV3.updateCbPlan(any(), anyString(), anyString(), any())).thenReturn(successResponse());
+        ResponseEntity<ApiResponse> response = controller.updateCbPlan(
+                apiRequest(), TOKEN, ORG_ID, Arrays.asList("ADMIN"));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Constants.SUCCESS, response.getBody().getParams().getStatus());
+    }
+
+    @Test
+    void testPublishCbPlan() {
+        when(cbPlanServiceV3.publishCbPlan(any(), anyString(), anyString(), any())).thenReturn(successResponse());
+        ResponseEntity<ApiResponse> response = controller.publishCbPlan(
+                apiRequest(), TOKEN, ORG_ID, Arrays.asList("ADMIN"));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Constants.SUCCESS, response.getBody().getParams().getStatus());
+    }
+
+    @Test
+    void testRetireCbPlan() {
+        when(cbPlanServiceV3.retireCbPlan(any(), anyString(), anyString(), any())).thenReturn(successResponse());
+        ResponseEntity<ApiResponse> response = controller.retireCbPlan(
+                apiRequest(), TOKEN, ORG_ID, Arrays.asList("ADMIN"));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Constants.SUCCESS, response.getBody().getParams().getStatus());
+    }
+
+    @Test
+    void testReadCbPlan() {
+        ApiResponse mockResponse = successResponse();
+        mockResponse.getResult().put(Constants.CONTENT, Map.of(Constants.ID, PLAN_ID));
+        when(cbPlanServiceV3.readCbPlan(anyString(), anyString(), anyString())).thenReturn(mockResponse);
+        ResponseEntity<ApiResponse> response = controller.readCbPlan(PLAN_ID, TOKEN, ORG_ID);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody().getResult().get(Constants.CONTENT));
+        verify(cbPlanServiceV3).readCbPlan(PLAN_ID, ORG_ID, TOKEN);
+    }
+
+    @Test
+    void testReadCbPlanPropagatesErrorStatus() {
+        ApiResponse mockResponse = new ApiResponse();
+        mockResponse.getParams().setStatus(Constants.FAILED);
+        mockResponse.setResponseCode(HttpStatus.BAD_REQUEST);
+        when(cbPlanServiceV3.readCbPlan(anyString(), anyString(), anyString())).thenReturn(mockResponse);
+        ResponseEntity<ApiResponse> response = controller.readCbPlan(PLAN_ID, TOKEN, ORG_ID);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(Constants.FAILED, response.getBody().getParams().getStatus());
+    }
+
+    @Test
+    void testSearchCbPlan() {
+        when(cbPlanServiceV3.searchCbPlan(any(), anyString(), anyString())).thenReturn(successResponse());
+        ResponseEntity<ApiResponse> response = controller.searchCbPlan(new SearchCriteria(), TOKEN, ORG_ID);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Constants.SUCCESS, response.getBody().getParams().getStatus());
+    }
+
+    @Test
+    void testGetCBPlanDictionary() {
+        ApiResponse mockResponse = successResponse();
+        mockResponse.getResult().put("aparCount", 2);
+        when(cbPlanServiceV3.getCBPlanDictionaryForUser(any(), anyString())).thenReturn(mockResponse);
+        ResponseEntity<ApiResponse> response = controller.getCBPlanDictionary(apiRequest(), TOKEN);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(2, response.getBody().getResult().get("aparCount"));
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanWithAccessSettingsV3(cbPlanServiceV3));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/dto/CbPlanContentOccurrenceTest.java
+++ b/src/test/java/com/igot/cb/cbplan/dto/CbPlanContentOccurrenceTest.java
@@ -1,0 +1,72 @@
+package com.igot.cb.cbplan.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CbPlanContentOccurrenceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Test
+    void testNoArgsConstructorDefaultsToNull() {
+        CbPlanContentOccurrence occurrence = new CbPlanContentOccurrence();
+        assertNull(occurrence.getPlanId());
+        assertNull(occurrence.getEndDate());
+    }
+
+    @Test
+    void testSetters() {
+        CbPlanContentOccurrence occurrence = new CbPlanContentOccurrence();
+        Instant endDate = Instant.now();
+        occurrence.setPlanId("plan123");
+        occurrence.setEndDate(endDate);
+        assertEquals("plan123", occurrence.getPlanId());
+        assertEquals(endDate, occurrence.getEndDate());
+    }
+
+    @Test
+    void testAllArgsConstructor() {
+        Instant endDate = Instant.now();
+        CbPlanContentOccurrence occurrence = new CbPlanContentOccurrence("plan456", endDate);
+        assertEquals("plan456", occurrence.getPlanId());
+        assertEquals(endDate, occurrence.getEndDate());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Instant endDate = Instant.now();
+        CbPlanContentOccurrence first = new CbPlanContentOccurrence("plan789", endDate);
+        CbPlanContentOccurrence second = new CbPlanContentOccurrence("plan789", endDate);
+        CbPlanContentOccurrence different = new CbPlanContentOccurrence("planOther", endDate);
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+        assertNotEquals(first, different);
+    }
+
+    @Test
+    void testToStringContainsPlanId() {
+        CbPlanContentOccurrence occurrence = new CbPlanContentOccurrence("plan123", Instant.EPOCH);
+        assertNotNull(occurrence.toString());
+    }
+
+    @Test
+    void testJsonRoundTripPreservesValues() throws Exception {
+        Instant endDate = Instant.parse("2026-08-12T10:15:30Z");
+        CbPlanContentOccurrence original = new CbPlanContentOccurrence("plan123", endDate);
+        String json = MAPPER.writeValueAsString(original);
+        CbPlanContentOccurrence restored = MAPPER.readValue(json, CbPlanContentOccurrence.class);
+        assertEquals(original, restored);
+        assertEquals(endDate, restored.getEndDate());
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/dto/CbPlanDictionaryCacheEntryTest.java
+++ b/src/test/java/com/igot/cb/cbplan/dto/CbPlanDictionaryCacheEntryTest.java
@@ -1,0 +1,76 @@
+package com.igot.cb.cbplan.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CbPlanDictionaryCacheEntryTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Test
+    void testNoArgsConstructorAndSetters() {
+        CbPlanDictionaryCacheEntry entry = new CbPlanDictionaryCacheEntry();
+        Map<String, List<CbPlanContentOccurrence>> aparMap = new LinkedHashMap<>();
+        aparMap.put("content1", List.of(new CbPlanContentOccurrence("plan1", Instant.EPOCH)));
+        Map<String, List<CbPlanContentOccurrence>> nonAparMap = new LinkedHashMap<>();
+        entry.setAparContentList(aparMap);
+        entry.setNonAparContentList(nonAparMap);
+        entry.setAparCount(1);
+        entry.setNonAparCount(0);
+        assertEquals(aparMap, entry.getAparContentList());
+        assertEquals(nonAparMap, entry.getNonAparContentList());
+        assertEquals(1, entry.getAparCount());
+        assertEquals(0, entry.getNonAparCount());
+    }
+
+    @Test
+    void testAllArgsConstructor() {
+        Map<String, List<CbPlanContentOccurrence>> aparMap = new LinkedHashMap<>();
+        Map<String, List<CbPlanContentOccurrence>> nonAparMap = new LinkedHashMap<>();
+        CbPlanDictionaryCacheEntry entry = new CbPlanDictionaryCacheEntry(aparMap, nonAparMap, 5, 3);
+        assertEquals(aparMap, entry.getAparContentList());
+        assertEquals(nonAparMap, entry.getNonAparContentList());
+        assertEquals(5, entry.getAparCount());
+        assertEquals(3, entry.getNonAparCount());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        CbPlanDictionaryCacheEntry first =
+                new CbPlanDictionaryCacheEntry(new LinkedHashMap<>(), new LinkedHashMap<>(), 0, 0);
+        CbPlanDictionaryCacheEntry second =
+                new CbPlanDictionaryCacheEntry(new LinkedHashMap<>(), new LinkedHashMap<>(), 0, 0);
+        CbPlanDictionaryCacheEntry different =
+                new CbPlanDictionaryCacheEntry(new LinkedHashMap<>(), new LinkedHashMap<>(), 1, 0);
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+        assertNotEquals(first, different);
+    }
+
+    @Test
+    void testJsonRoundTripMatchesRedisCacheContract() throws Exception {
+        Map<String, List<CbPlanContentOccurrence>> aparMap = new LinkedHashMap<>();
+        aparMap.put("course1", List.of(new CbPlanContentOccurrence("plan1", Instant.parse("2026-08-12T10:15:30Z"))));
+        CbPlanDictionaryCacheEntry original =
+                new CbPlanDictionaryCacheEntry(aparMap, new LinkedHashMap<>(), 1, 0);
+        String json = MAPPER.writeValueAsString(original);
+        CbPlanDictionaryCacheEntry restored = MAPPER.readValue(json, CbPlanDictionaryCacheEntry.class);
+        assertTrue(json.contains("aparContentList"));
+        assertTrue(json.contains("nonAparCount"));
+        assertEquals(original, restored);
+        assertEquals("plan1", restored.getAparContentList().get("course1").get(0).getPlanId());
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/dto/CbPlanReadResponseDtoTest.java
+++ b/src/test/java/com/igot/cb/cbplan/dto/CbPlanReadResponseDtoTest.java
@@ -1,0 +1,101 @@
+package com.igot.cb.cbplan.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CbPlanReadResponseDtoTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void testBuilderPopulatesAllFields() throws Exception {
+        Instant createdAt = Instant.parse("2026-01-01T00:00:00Z");
+        Instant publishedAt = Instant.parse("2026-02-01T00:00:00Z");
+        Instant endDate = Instant.parse("2026-12-31T18:29:59Z");
+        JsonNode contextData = MAPPER.readTree("{\"accessControl\":{\"userGroups\":[]}}");
+        List<Map<String, Object>> contentList = List.of(Map.of("identifier", "course1"));
+        CbPlanReadResponseDto dto = CbPlanReadResponseDto.builder()
+                .id("plan123")
+                .name("My Plan")
+                .planYear("2026-27")
+                .endDate(endDate)
+                .isApar(true)
+                .contentType("Course")
+                .planType("AI CBP")
+                .createdAt(createdAt)
+                .cbPublishedAt(publishedAt)
+                .status("Live")
+                .createdBy("user1")
+                .createdByName("John")
+                .contextData(contextData)
+                .contentList(contentList)
+                .build();
+        assertEquals("plan123", dto.getId());
+        assertEquals("My Plan", dto.getName());
+        assertEquals("2026-27", dto.getPlanYear());
+        assertEquals(endDate, dto.getEndDate());
+        assertTrue(dto.getIsApar());
+        assertEquals("Course", dto.getContentType());
+        assertEquals("AI CBP", dto.getPlanType());
+        assertEquals(createdAt, dto.getCreatedAt());
+        assertEquals(publishedAt, dto.getCbPublishedAt());
+        assertEquals("Live", dto.getStatus());
+        assertEquals("user1", dto.getCreatedBy());
+        assertEquals("John", dto.getCreatedByName());
+        assertEquals(contextData, dto.getContextData());
+        assertEquals(contentList, dto.getContentList());
+    }
+
+    @Test
+    void testBuilderLeavesUnsetFieldsNull() {
+        CbPlanReadResponseDto dto = CbPlanReadResponseDto.builder().id("plan123").build();
+        assertEquals("plan123", dto.getId());
+        assertNull(dto.getName());
+        assertNull(dto.getEndDate());
+        assertNull(dto.getContextData());
+        assertNull(dto.getContentList());
+    }
+
+    @Test
+    void testNoArgsConstructorAndSetters() {
+        CbPlanReadResponseDto dto = new CbPlanReadResponseDto();
+        dto.setId("plan999");
+        dto.setName("Updated Plan");
+        dto.setIsApar(false);
+        dto.setStatus("draft");
+        assertEquals("plan999", dto.getId());
+        assertEquals("Updated Plan", dto.getName());
+        assertEquals(Boolean.FALSE, dto.getIsApar());
+        assertEquals("draft", dto.getStatus());
+    }
+
+    @Test
+    void testAllArgsConstructor() {
+        CbPlanReadResponseDto dto = new CbPlanReadResponseDto("plan1", "name", "2026-27",
+                Instant.EPOCH, false, "Course", "type", Instant.EPOCH, Instant.EPOCH,
+                "Live", "user1", "John", null, List.of());
+        assertEquals("plan1", dto.getId());
+        assertEquals("2026-27", dto.getPlanYear());
+        assertNull(dto.getContextData());
+        assertTrue(dto.getContentList().isEmpty());
+    }
+
+    @Test
+    void testDeserializationIgnoresUnknownProperties() throws Exception {
+        String json = "{\"id\":\"plan123\",\"name\":\"Plan\",\"someRemovedField\":\"value\"}";
+        CbPlanReadResponseDto dto = MAPPER.readValue(json, CbPlanReadResponseDto.class);
+        assertNotNull(dto);
+        assertEquals("plan123", dto.getId());
+        assertEquals("Plan", dto.getName());
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanContentLookupServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanContentLookupServiceV3ImplTest.java
@@ -1,0 +1,282 @@
+package com.igot.cb.cbplan.service.impl;
+
+import com.igot.cb.cache.RedisCacheMgr;
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.service.OutboundRequestHandlerServiceImpl;
+import com.igot.cb.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanContentLookupServiceV3ImplTest {
+
+    private static final String PLAN_ID = "plan1";
+    private static final String CONTENT_ID = "content1";
+
+    @Mock
+    private CassandraOperation cassandraOperation;
+
+    @Mock
+    private RedisCacheMgr redisCacheMgr;
+
+    @Mock
+    private OutboundRequestHandlerServiceImpl outboundRequestHandlerService;
+
+    @InjectMocks
+    private CbPlanContentLookupServiceV3Impl contentLookupService;
+
+    private static Map<String, Object> lookupRow(String... planIds) {
+        Map<String, Object> row = new HashMap<>();
+        row.put(Constants.PLAN_ID, new HashSet<>(Set.of(planIds)));
+        return row;
+    }
+
+    private void stubLookupRows(List<Map<String, Object>> rows) {
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    @Test
+    void testUpdateContentLookupWithContent() {
+        Map<String, Object> planData = new HashMap<>();
+        planData.put(Constants.CONTENT_LIST, List.of("content1", "content2"));
+        stubLookupRows(List.of());
+        contentLookupService.updateContentLookup(PLAN_ID, planData);
+        verify(cassandraOperation, times(2)).updateRecord(anyString(), anyString(), anyMap(), anyMap());
+    }
+
+    @Test
+    void testUpdateContentLookupSkipsWhenNoContent() {
+        contentLookupService.updateContentLookup(PLAN_ID, new HashMap<>());
+        verify(cassandraOperation, never()).updateRecord(anyString(), anyString(), anyMap(), anyMap());
+    }
+
+    @Test
+    void testUpsertAddsPlanIdWhenAbsent() {
+        stubLookupRows(List.of());
+        contentLookupService.upsertCbPlanContentLookup(PLAN_ID, List.of(CONTENT_ID));
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(cassandraOperation).updateRecord(anyString(), anyString(), captor.capture(), anyMap());
+        Set<String> planIds = (Set<String>) captor.getValue().get(Constants.PLAN_ID_COLUMN);
+        assertTrue(planIds.contains(PLAN_ID));
+    }
+
+    @Test
+    void testUpsertMergesWithExistingPlanIds() {
+        stubLookupRows(List.of(lookupRow("existingPlan")));
+        contentLookupService.upsertCbPlanContentLookup(PLAN_ID, List.of(CONTENT_ID));
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(cassandraOperation).updateRecord(anyString(), anyString(), captor.capture(), anyMap());
+        Set<String> planIds = (Set<String>) captor.getValue().get(Constants.PLAN_ID_COLUMN);
+        assertEquals(Set.of(PLAN_ID, "existingPlan"), planIds);
+    }
+
+    @Test
+    void testUpsertSkipsWhenPlanIdAlreadyPresent() {
+        stubLookupRows(List.of(lookupRow(PLAN_ID)));
+        contentLookupService.upsertCbPlanContentLookup(PLAN_ID, List.of(CONTENT_ID));
+        verify(cassandraOperation, never()).updateRecord(anyString(), anyString(), anyMap(), anyMap());
+    }
+
+    @Test
+    void testUpdateContentLookupForModifiedPlanHandlesAddsAndDeletes() {
+        Map<String, Object> updatedRequest = new HashMap<>();
+        updatedRequest.put(Constants.CONTENT_LIST, List.of("content1", "content2"));
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CONTENT_LIST, List.of("content2", "content3"));
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenAnswer(invocation -> {
+                    Map<String, Object> where = invocation.getArgument(2);
+                    String contentId = (String) where.get(Constants.CONTENT_ID_COLUMN);
+                    return "content1".equals(contentId)
+                            ? List.of(lookupRow("otherPlan"))
+                            : List.of(lookupRow(PLAN_ID));
+                });
+        contentLookupService.updateContentLookupForModifiedPlan(PLAN_ID, updatedRequest, existingCbPlan);
+        verify(cassandraOperation, times(1)).updateRecord(anyString(), anyString(), anyMap(), anyMap());
+        verify(cassandraOperation, times(1)).deleteRecord(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void testUpdateContentLookupForModifiedPlanSkipsWhenNoUpdatedContent() {
+        contentLookupService.updateContentLookupForModifiedPlan(PLAN_ID, new HashMap<>(), new HashMap<>());
+        verify(cassandraOperation, never()).getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any());
+    }
+
+    @Test
+    void testRemoveFromContentLookupWithContent() {
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CONTENT_LIST, List.of(CONTENT_ID));
+        stubLookupRows(List.of(lookupRow(PLAN_ID)));
+        contentLookupService.removeFromContentLookup(PLAN_ID, existingCbPlan);
+        verify(cassandraOperation).deleteRecord(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void testRemoveFromContentLookupSkipsWhenNoContent() {
+        contentLookupService.removeFromContentLookup(PLAN_ID, new HashMap<>());
+        verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void testRemoveDeletesRowWhenLastPlan() {
+        stubLookupRows(List.of(lookupRow(PLAN_ID)));
+        contentLookupService.removeCbPlanInfoForUpdateOrDeleteCbPlan(PLAN_ID, List.of(CONTENT_ID));
+        verify(cassandraOperation).deleteRecord(anyString(), anyString(), anyMap());
+        verify(cassandraOperation, never()).updateRecord(anyString(), anyString(), anyMap(), anyMap());
+    }
+
+    @Test
+    void testRemoveUpdatesRowWhenOtherPlansRemain() {
+        stubLookupRows(List.of(lookupRow(PLAN_ID, "plan2")));
+        contentLookupService.removeCbPlanInfoForUpdateOrDeleteCbPlan(PLAN_ID, List.of(CONTENT_ID));
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(cassandraOperation).updateRecord(anyString(), anyString(), captor.capture(), anyMap());
+        assertEquals(Set.of("plan2"), captor.getValue().get(Constants.PLAN_ID_COLUMN));
+        verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void testRemoveSkipsWhenPlanNotInSet() {
+        stubLookupRows(List.of(lookupRow("otherPlan")));
+        contentLookupService.removeCbPlanInfoForUpdateOrDeleteCbPlan(PLAN_ID, List.of(CONTENT_ID));
+        verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+        verify(cassandraOperation, never()).updateRecord(anyString(), anyString(), anyMap(), anyMap());
+    }
+
+    @Test
+    void testRemoveSkipsWhenNoRowFound() {
+        stubLookupRows(List.of());
+        contentLookupService.removeCbPlanInfoForUpdateOrDeleteCbPlan(PLAN_ID, List.of(CONTENT_ID));
+        verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void testRemoveSkipsWhenPlanIdColumnHasWrongType() {
+        Map<String, Object> row = new HashMap<>();
+        row.put(Constants.PLAN_ID, "not-a-set");
+        stubLookupRows(List.of(row));
+        contentLookupService.removeCbPlanInfoForUpdateOrDeleteCbPlan(PLAN_ID, List.of(CONTENT_ID));
+        verify(cassandraOperation, never()).deleteRecord(anyString(), anyString(), anyMap());
+        verify(cassandraOperation, never()).updateRecord(anyString(), anyString(), anyMap(), anyMap());
+    }
+
+    @Test
+    void testGetAddedContent() {
+        assertEquals(List.of("content2"),
+                contentLookupService.getAddedContent(List.of("content1"), List.of("content1", "content2")));
+    }
+
+    @Test
+    void testGetAddedContentWithNullExisting() {
+        assertEquals(List.of("content1"), contentLookupService.getAddedContent(null, List.of("content1")));
+    }
+
+    @Test
+    void testGetAddedContentWithBothNull() {
+        assertTrue(contentLookupService.getAddedContent(null, null).isEmpty());
+    }
+
+    @Test
+    void testGetDeletedContent() {
+        assertEquals(List.of("content2"),
+                contentLookupService.getDeletedContent(List.of("content1", "content2"), List.of("content1")));
+    }
+
+    @Test
+    void testGetDeletedContentWithNullUpdated() {
+        assertEquals(List.of("content1"), contentLookupService.getDeletedContent(List.of("content1"), null));
+    }
+
+    @Test
+    void testGetContentMetadataReturnsCachedValueOnRedisHit() throws Exception {
+        when(redisCacheMgr.getFromCache(Constants.EXTENDED_READ_CONTENT_CACHE_KEY_PREFIX + CONTENT_ID))
+                .thenReturn("{\"identifier\":\"content1\",\"name\":\"Course 1\"}");
+        Map<String, Object> result = contentLookupService.getContentMetadata(CONTENT_ID);
+        assertEquals("Course 1", result.get("name"));
+        verify(outboundRequestHandlerService, never()).fetchResult(anyString());
+    }
+
+    @Test
+    void testGetContentMetadataFallsBackToExtendedReadApiOnCacheMiss() throws Exception {
+        when(redisCacheMgr.getFromCache(anyString())).thenReturn(null);
+        Map<String, Object> apiResponse = new HashMap<>();
+        apiResponse.put(Constants.RESPONSE_CODE, Constants.OK);
+        apiResponse.put(Constants.RESULT, Map.of(Constants.CONTENT, Map.of("name", "Course 1")));
+        when(outboundRequestHandlerService.fetchResult(anyString())).thenReturn(apiResponse);
+        Map<String, Object> result = contentLookupService.getContentMetadata(CONTENT_ID);
+        assertEquals("Course 1", result.get("name"));
+    }
+
+    @Test
+    void testGetContentMetadataReturnsEmptyMapOnNonOkApiResponse() throws Exception {
+        when(redisCacheMgr.getFromCache(anyString())).thenReturn(null);
+        Map<String, Object> apiResponse = new HashMap<>();
+        apiResponse.put(Constants.RESPONSE_CODE, "SERVER_ERROR");
+        when(outboundRequestHandlerService.fetchResult(anyString())).thenReturn(apiResponse);
+        assertTrue(contentLookupService.getContentMetadata(CONTENT_ID).isEmpty());
+    }
+
+    @Test
+    void testGetContentMetadataReturnsEmptyMapWhenApiReturnsNull() throws Exception {
+        when(redisCacheMgr.getFromCache(anyString())).thenReturn(null);
+        when(outboundRequestHandlerService.fetchResult(anyString())).thenReturn(null);
+        assertTrue(contentLookupService.getContentMetadata(CONTENT_ID).isEmpty());
+    }
+
+    @Test
+    void testGetContentMetadataUsesExternalContentApiForExtPrefix() throws Exception {
+        String externalContentId = Constants.EXTERNAL_CONTENT_PREFIX + "event1";
+        when(redisCacheMgr.getFromCache(anyString())).thenReturn(null);
+        Map<String, Object> apiResponse = new HashMap<>();
+        apiResponse.put(Constants.RESULT, Map.of(Constants.EVENT, Map.of("name", "Event 1")));
+        when(outboundRequestHandlerService.fetchResult(anyString())).thenReturn(apiResponse);
+        Map<String, Object> result = contentLookupService.getContentMetadata(externalContentId);
+        assertEquals("Event 1", result.get("name"));
+    }
+
+    @Test
+    void testGetContentMetadataReturnsEmptyMapWhenExternalEventMissing() throws Exception {
+        String externalContentId = Constants.EXTERNAL_CONTENT_PREFIX + "event1";
+        when(redisCacheMgr.getFromCache(anyString())).thenReturn(null);
+        Map<String, Object> apiResponse = new HashMap<>();
+        apiResponse.put(Constants.RESULT, new HashMap<String, Object>());
+        when(outboundRequestHandlerService.fetchResult(anyString())).thenReturn(apiResponse);
+        assertTrue(contentLookupService.getContentMetadata(externalContentId).isEmpty());
+    }
+
+    @Test
+    void testGetContentMetadataSwallowsApiExceptions() throws Exception {
+        when(redisCacheMgr.getFromCache(anyString())).thenReturn(null);
+        when(outboundRequestHandlerService.fetchResult(anyString()))
+                .thenThrow(new RuntimeException("content service down"));
+        assertTrue(contentLookupService.getContentMetadata(CONTENT_ID).isEmpty());
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanContentLookupServiceV3Impl(
+                cassandraOperation, redisCacheMgr, outboundRequestHandlerService));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanDataTransformServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanDataTransformServiceV3ImplTest.java
@@ -1,0 +1,251 @@
+package com.igot.cb.cbplan.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.CbExtServerProperties;
+import com.igot.cb.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanDataTransformServiceV3ImplTest {
+
+    private static final String USER_ID = "user1";
+
+    @Mock
+    private CbExtServerProperties serverProperties;
+
+    @InjectMocks
+    private CbPlanDataTransformServiceV3Impl dataTransformService;
+
+    private static ApiRequest apiRequest(Map<String, Object> requestMap) {
+        ApiRequest request = new ApiRequest();
+        request.setRequest(requestMap);
+        return request;
+    }
+
+    @Test
+    void testPrepareCbPlanForInsertPopulatesSystemFields() throws JsonProcessingException {
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.NAME, "planName");
+        requestMap.put(Constants.CONTENT_LIST, List.of("content1"));
+        requestMap.put(Constants.PLAN_YEAR, "2026-27");
+        Map<String, Object> result = dataTransformService.prepareCbPlanForInsert(apiRequest(requestMap), USER_ID);
+        assertNotNull(result.get(Constants.PLAN_ID));
+        assertEquals(USER_ID, result.get(Constants.CREATED_BY));
+        assertNotNull(result.get(Constants.CREATED_AT));
+        assertEquals(Constants.DRAFT, result.get(Constants.STATUS));
+        assertEquals("planName", result.get(Constants.NAME));
+        assertEquals("2026-27", result.get(Constants.PLAN_YEAR));
+        assertEquals(List.of("content1"), result.get(Constants.CONTENT_LIST));
+    }
+
+    @Test
+    void testPrepareCbPlanForInsertDefaultsIsAparToFalse() throws JsonProcessingException {
+        Map<String, Object> result = dataTransformService.prepareCbPlanForInsert(
+                apiRequest(new HashMap<>()), USER_ID);
+        assertEquals(false, result.get(Constants.IS_APAR));
+    }
+
+    @Test
+    void testPrepareCbPlanForInsertOmitsPlanTypeWhenAbsent() throws JsonProcessingException {
+        Map<String, Object> result = dataTransformService.prepareCbPlanForInsert(
+                apiRequest(new HashMap<>()), USER_ID);
+        assertFalse(result.containsKey(Constants.PLAN_TYPE));
+    }
+
+    @Test
+    void testPrepareCbPlanForInsertIncludesPlanTypeWhenPresent() throws JsonProcessingException {
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.PLAN_TYPE, "AI CBP");
+        Map<String, Object> result = dataTransformService.prepareCbPlanForInsert(apiRequest(requestMap), USER_ID);
+        assertEquals("AI CBP", result.get(Constants.PLAN_TYPE));
+    }
+
+    @Test
+    void testPrepareCbPlanForUpdateSetsAuditFields() throws JsonProcessingException {
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.NAME, "updatedName");
+        Map<String, Object> result = dataTransformService.prepareCbPlanForUpdate(incomingRequest, USER_ID);
+        assertEquals(USER_ID, result.get(Constants.UPDATED_BY));
+        assertNotNull(result.get(Constants.UPDATED_AT));
+        assertEquals("updatedName", result.get(Constants.NAME));
+    }
+
+    @Test
+    void testPrepareBasicPublishUpdate() {
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.COMMENT, "publish comment");
+        Map<String, Object> result = dataTransformService.prepareBasicPublishUpdate(incomingRequest, USER_ID);
+        assertEquals(USER_ID, result.get(Constants.PUBLISHED_BY));
+        assertEquals(USER_ID, result.get(Constants.UPDATED_BY));
+        assertEquals("publish comment", result.get(Constants.COMMENT));
+        assertNotNull(result.get(Constants.PUBLISHED_AT));
+        assertNotNull(result.get(Constants.UPDATED_AT));
+    }
+
+    @Test
+    void testPrepareArchiveUpdateWithComment() {
+        Map<String, Object> result = dataTransformService.prepareArchiveUpdate("archive reason", USER_ID);
+        assertEquals(Constants.CB_RETIRE, result.get(Constants.STATUS));
+        assertEquals(USER_ID, result.get(Constants.UPDATED_BY));
+        assertEquals("archive reason", result.get(Constants.COMMENT));
+        assertNotNull(result.get(Constants.UPDATED_AT));
+    }
+
+    @Test
+    void testPrepareArchiveUpdateOmitsNullComment() {
+        Map<String, Object> result = dataTransformService.prepareArchiveUpdate(null, USER_ID);
+        assertEquals(Constants.CB_RETIRE, result.get(Constants.STATUS));
+        assertFalse(result.containsKey(Constants.COMMENT));
+    }
+
+    @Test
+    void testParseEndDateReturnsNullForNull() {
+        assertNull(dataTransformService.parseEndDate(null));
+    }
+
+    @Test
+    void testParseEndDateFromDate() {
+        Date date = new Date();
+        assertEquals(date.toInstant(), dataTransformService.parseEndDate(date));
+    }
+
+    @Test
+    void testParseEndDateFromInstant() {
+        Instant instant = Instant.now();
+        assertEquals(instant, dataTransformService.parseEndDate(instant));
+    }
+
+    @Test
+    void testParseEndDateFromEpochMillis() {
+        long epochMilli = 1700000000000L;
+        assertEquals(Instant.ofEpochMilli(epochMilli), dataTransformService.parseEndDate(epochMilli));
+    }
+
+    @Test
+    void testParseEndDateFromIsoString() {
+        String isoString = "2026-08-12T10:15:30Z";
+        assertEquals(Instant.parse(isoString), dataTransformService.parseEndDate(isoString));
+    }
+
+    @Test
+    void testParseEndDateFromDateOnlyStringUsesEndOfDayKolkata() {
+        Instant result = dataTransformService.parseEndDate("2026-08-12");
+        assertEquals("2026-08-12T18:29:59Z", result.toString());
+    }
+
+    @Test
+    void testParseEndDateThrowsForUnparseableString() {
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> dataTransformService.parseEndDate("not-a-date"));
+        assertTrue(exception.getMessage().contains("not-a-date"));
+    }
+
+    @Test
+    void testParseEndDateReturnsNullForUnsupportedType() {
+        assertNull(dataTransformService.parseEndDate(new Object()));
+    }
+
+    @Test
+    void testBuildUpdatedPlanForLiveSuccess() {
+        when(serverProperties.getCbPlanUpdateAllowedFields()).thenReturn(List.of(Constants.NAME));
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.NAME, "updatedName");
+        Set<String> rootOrgIds = Set.of("org1");
+        Map<String, Object> result = dataTransformService.buildUpdatedPlanForLive(
+                incomingRequest, new HashMap<>(), USER_ID, rootOrgIds, new ApiResponse());
+        assertEquals("updatedName", result.get(Constants.NAME));
+        assertEquals(USER_ID, result.get(Constants.UPDATED_BY));
+        assertNotNull(result.get(Constants.UPDATED_AT));
+        assertEquals(List.of("org1"), result.get(Constants.ROOT_ORG_IDS_IN_CONTEXT_DATA));
+    }
+
+    @Test
+    void testBuildUpdatedPlanForLiveIgnoresFieldsNotInRequest() {
+        when(serverProperties.getCbPlanUpdateAllowedFields())
+                .thenReturn(List.of(Constants.NAME, Constants.COMMENT));
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.NAME, "updatedName");
+        Map<String, Object> result = dataTransformService.buildUpdatedPlanForLive(
+                incomingRequest, new HashMap<>(), USER_ID, new HashSet<>(), new ApiResponse());
+        assertEquals("updatedName", result.get(Constants.NAME));
+        assertFalse(result.containsKey(Constants.COMMENT));
+    }
+
+    @Test
+    void testBuildUpdatedPlanForLiveFailsWhenAllowedFieldIsNull() {
+        when(serverProperties.getCbPlanUpdateAllowedFields()).thenReturn(List.of(Constants.NAME));
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.NAME, null);
+        ApiResponse response = new ApiResponse();
+        Map<String, Object> result = dataTransformService.buildUpdatedPlanForLive(
+                incomingRequest, new HashMap<>(), USER_ID, new HashSet<>(), response);
+        assertTrue(result.isEmpty());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testBuildUpdatedPlanForLiveRejectsDowngradingIsApar() {
+        when(serverProperties.getCbPlanUpdateAllowedFields()).thenReturn(List.of(Constants.IS_APAR));
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.IS_APAR, false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.IS_APAR, true);
+        ApiResponse response = new ApiResponse();
+        Map<String, Object> result = dataTransformService.buildUpdatedPlanForLive(
+                incomingRequest, existingCbPlan, USER_ID, new HashSet<>(), response);
+        assertTrue(result.isEmpty());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testBuildUpdatedPlanForLiveAllowsKeepingIsAparTrue() {
+        when(serverProperties.getCbPlanUpdateAllowedFields()).thenReturn(List.of(Constants.IS_APAR));
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.IS_APAR, true);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.IS_APAR, true);
+        Map<String, Object> result = dataTransformService.buildUpdatedPlanForLive(
+                incomingRequest, existingCbPlan, USER_ID, new HashSet<>(), new ApiResponse());
+        assertEquals(true, result.get(Constants.IS_APAR));
+    }
+
+    @Test
+    void testBuildUpdatedPlanForLiveAllowsEnablingIsAparOnNonAparPlan() {
+        when(serverProperties.getCbPlanUpdateAllowedFields()).thenReturn(List.of(Constants.IS_APAR));
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.IS_APAR, true);
+        Map<String, Object> result = dataTransformService.buildUpdatedPlanForLive(
+                incomingRequest, new HashMap<>(), USER_ID, new HashSet<>(), new ApiResponse());
+        assertEquals(true, result.get(Constants.IS_APAR));
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanDataTransformServiceV3Impl(serverProperties));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanElasticSearchServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanElasticSearchServiceV3ImplTest.java
@@ -1,0 +1,129 @@
+package com.igot.cb.cbplan.service.impl;
+
+import com.igot.cb.elasticsearch.service.EsUtilService;
+import com.igot.cb.util.CbExtServerProperties;
+import com.igot.cb.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanElasticSearchServiceV3ImplTest {
+
+    private static final String ES_INDEX = "cbplan-index";
+    private static final String JSON_PATH = "path.json";
+    private static final String PLAN_ID = "plan1";
+
+    @Mock
+    private EsUtilService esUtilService;
+
+    @Mock
+    private CbExtServerProperties serverProperties;
+
+    @InjectMocks
+    private CbPlanElasticSearchServiceV3Impl elasticSearchService;
+
+    private void stubEsProperties() {
+        when(serverProperties.getCpPlanIndex()).thenReturn(ES_INDEX);
+        when(serverProperties.getElasticCbPlanJsonPath()).thenReturn(JSON_PATH);
+    }
+
+    @Test
+    void testIndexToElasticSearchAddsIdAndSanitizes() {
+        stubEsProperties();
+        Instant createdAt = Instant.parse("2026-08-12T10:15:30Z");
+        Map<String, Object> planData = new HashMap<>();
+        planData.put(Constants.NAME, "planName");
+        planData.put(Constants.CREATED_AT, createdAt);
+        elasticSearchService.indexToElasticSearch(PLAN_ID, planData);
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(esUtilService).addDocument(eq(ES_INDEX), eq(Constants.INDEX_TYPE), eq(PLAN_ID),
+                captor.capture(), eq(JSON_PATH));
+        Map<String, Object> indexed = captor.getValue();
+        assertEquals(PLAN_ID, indexed.get(Constants.ID));
+        assertEquals(DateTimeFormatter.ISO_INSTANT.format(createdAt), indexed.get(Constants.CREATED_AT));
+        assertEquals("planName", indexed.get(Constants.NAME));
+    }
+
+    @Test
+    void testUpdateElasticSearchForPlan() {
+        stubEsProperties();
+        Map<String, Object> updatedRequest = new HashMap<>();
+        updatedRequest.put(Constants.NAME, "updatedName");
+        elasticSearchService.updateElasticSearchForPlan(PLAN_ID, updatedRequest);
+        verify(esUtilService).updateDocument(eq(ES_INDEX), eq(Constants.INDEX_TYPE), eq(PLAN_ID),
+                anyMap(), eq(JSON_PATH));
+    }
+
+    @Test
+    void testUpdateElasticSearchForArchiveMergesAndForcesRetireStatus() {
+        stubEsProperties();
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.NAME, "planName");
+        existingCbPlan.put(Constants.STATUS, Constants.LIVE);
+        Map<String, Object> updateData = new HashMap<>();
+        updateData.put(Constants.COMMENT, "archived");
+        elasticSearchService.updateElasticSearchForArchive(PLAN_ID, existingCbPlan, updateData);
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(esUtilService).addDocument(eq(ES_INDEX), eq(Constants.INDEX_TYPE), eq(PLAN_ID),
+                captor.capture(), eq(JSON_PATH));
+        Map<String, Object> indexed = captor.getValue();
+        assertEquals(Constants.CB_RETIRE, indexed.get(Constants.STATUS));
+        assertEquals(PLAN_ID, indexed.get(Constants.ID));
+        assertEquals("planName", indexed.get(Constants.NAME));
+        assertEquals("archived", indexed.get(Constants.COMMENT));
+    }
+
+    @Test
+    void testUpdateElasticSearchForArchiveDoesNotMutateExistingPlan() {
+        stubEsProperties();
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.STATUS, Constants.LIVE);
+        elasticSearchService.updateElasticSearchForArchive(PLAN_ID, existingCbPlan, new HashMap<>());
+        assertEquals(Constants.LIVE, existingCbPlan.get(Constants.STATUS));
+    }
+
+    @Test
+    void testSanitizeForElasticConvertsInstantToIsoString() {
+        Instant now = Instant.parse("2026-08-12T10:15:30Z");
+        Map<String, Object> input = new HashMap<>();
+        input.put(Constants.CREATED_AT, now);
+        input.put(Constants.NAME, "planName");
+        input.put(Constants.CONTENT_LIST, List.of("course1"));
+        Map<String, Object> sanitized = elasticSearchService.sanitizeForElastic(input);
+        assertEquals("2026-08-12T10:15:30Z", sanitized.get(Constants.CREATED_AT));
+        assertEquals("planName", sanitized.get(Constants.NAME));
+        assertEquals(List.of("course1"), sanitized.get(Constants.CONTENT_LIST));
+    }
+
+    @Test
+    void testSanitizeForElasticHandlesEmptyAndNullValues() {
+        Map<String, Object> input = new HashMap<>();
+        input.put(Constants.NAME, null);
+        Map<String, Object> sanitized = elasticSearchService.sanitizeForElastic(input);
+        assertTrue(sanitized.containsKey(Constants.NAME));
+        assertTrue(elasticSearchService.sanitizeForElastic(new HashMap<>()).isEmpty());
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanElasticSearchServiceV3Impl(esUtilService, serverProperties));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanEnrichmentServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanEnrichmentServiceV3ImplTest.java
@@ -1,0 +1,142 @@
+package com.igot.cb.cbplan.service.impl;
+
+import com.igot.cb.service.ContentInfoServiceImpl;
+import com.igot.cb.service.UserAndOrgServiceImpl;
+import com.igot.cb.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanEnrichmentServiceV3ImplTest {
+
+    @Mock
+    private UserAndOrgServiceImpl userAndOrgService;
+
+    @Mock
+    private ContentInfoServiceImpl contentService;
+
+    @InjectMocks
+    private CbPlanEnrichmentServiceV3Impl enrichmentService;
+
+    @Test
+    void testEnrichSearchResultsEnrichesCreatedByAndContentList() {
+        Map<String, Object> item = new HashMap<>();
+        item.put(Constants.CREATED_BY, "user1");
+        item.put(Constants.CONTENT_LIST, List.of("content1"));
+        Map<String, Object> userInfoMap = new HashMap<>();
+        userInfoMap.put(Constants.FIRSTNAME, "John");
+        when(userAndOrgService.readUserProfile(any(), anyList())).thenReturn(userInfoMap);
+        List<Map<String, Object>> contentDetails = new ArrayList<>();
+        contentDetails.add(Map.of("identifier", "content1"));
+        when(contentService.enrichContentInfoForCBPlan(anyList())).thenReturn(contentDetails);
+        List<Map<String, Object>> result = enrichmentService.enrichSearchResults(List.of(item));
+        assertEquals(1, result.size());
+        assertEquals("John", result.get(0).get(Constants.CREATED_BY_NAME));
+        assertEquals("user1", result.get(0).get(Constants.CREATED_BY));
+        assertEquals(contentDetails, result.get(0).get(Constants.CONTENT_LIST));
+    }
+
+    @Test
+    void testEnrichSearchResultsDoesNotMutateSourceItems() {
+        Map<String, Object> item = new HashMap<>();
+        item.put(Constants.CONTENT_LIST, List.of("content1"));
+        when(contentService.enrichContentInfoForCBPlan(anyList()))
+                .thenReturn(List.of(Map.of("identifier", "content1")));
+        enrichmentService.enrichSearchResults(List.of(item));
+        assertEquals(List.of("content1"), item.get(Constants.CONTENT_LIST));
+    }
+
+    @Test
+    void testEnrichSearchResultsWithEmptyInput() {
+        assertTrue(enrichmentService.enrichSearchResults(List.of()).isEmpty());
+    }
+
+    @Test
+    void testEnrichCreatedByInfoSkipsWhenKeyMissing() {
+        Map<String, Object> enrichedItem = new HashMap<>();
+        enrichmentService.enrichCreatedByInfo(new HashMap<>(), enrichedItem);
+        assertTrue(enrichedItem.isEmpty());
+        verify(userAndOrgService, never()).readUserProfile(any(), anyList());
+    }
+
+    @Test
+    void testEnrichCreatedByInfoSkipsWhenValueNull() {
+        Map<String, Object> item = new HashMap<>();
+        item.put(Constants.CREATED_BY, null);
+        Map<String, Object> enrichedItem = new HashMap<>();
+        enrichmentService.enrichCreatedByInfo(item, enrichedItem);
+        assertTrue(enrichedItem.isEmpty());
+        verify(userAndOrgService, never()).readUserProfile(any(), anyList());
+    }
+
+    @Test
+    void testEnrichCreatedByInfoSkipsWhenValueBlank() {
+        Map<String, Object> item = new HashMap<>();
+        item.put(Constants.CREATED_BY, "   ");
+        Map<String, Object> enrichedItem = new HashMap<>();
+        enrichmentService.enrichCreatedByInfo(item, enrichedItem);
+        assertTrue(enrichedItem.isEmpty());
+        verify(userAndOrgService, never()).readUserProfile(any(), anyList());
+    }
+
+    @Test
+    void testEnrichCreatedByInfoSkipsWhenUserInfoEmpty() {
+        Map<String, Object> item = new HashMap<>();
+        item.put(Constants.CREATED_BY, "user1");
+        Map<String, Object> enrichedItem = new HashMap<>();
+        when(userAndOrgService.readUserProfile(any(), anyList())).thenReturn(new HashMap<>());
+        enrichmentService.enrichCreatedByInfo(item, enrichedItem);
+        assertFalse(enrichedItem.containsKey(Constants.CREATED_BY_NAME));
+    }
+
+    @Test
+    void testEnrichContentListInfoSkipsWhenKeyMissing() {
+        Map<String, Object> enrichedItem = new HashMap<>();
+        enrichmentService.enrichContentListInfo(new HashMap<>(), enrichedItem);
+        assertTrue(enrichedItem.isEmpty());
+        verify(contentService, never()).enrichContentInfoForCBPlan(anyList());
+    }
+
+    @Test
+    void testEnrichContentListInfoSkipsWhenValueNull() {
+        Map<String, Object> item = new HashMap<>();
+        item.put(Constants.CONTENT_LIST, null);
+        Map<String, Object> enrichedItem = new HashMap<>();
+        enrichmentService.enrichContentListInfo(item, enrichedItem);
+        assertTrue(enrichedItem.isEmpty());
+        verify(contentService, never()).enrichContentInfoForCBPlan(anyList());
+    }
+
+    @Test
+    void testEnrichContentListInfoSkipsWhenValueNotAList() {
+        Map<String, Object> item = new HashMap<>();
+        item.put(Constants.CONTENT_LIST, "not-a-list");
+        Map<String, Object> enrichedItem = new HashMap<>();
+        enrichmentService.enrichContentListInfo(item, enrichedItem);
+        assertTrue(enrichedItem.isEmpty());
+        verify(contentService, never()).enrichContentInfoForCBPlan(anyList());
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanEnrichmentServiceV3Impl(userAndOrgService, contentService));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanOrgLookupServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanOrgLookupServiceV3ImplTest.java
@@ -1,0 +1,302 @@
+package com.igot.cb.cbplan.service.impl;
+
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanOrgLookupServiceV3ImplTest {
+
+    private static final String PLAN_ID = "plan1";
+    private static final String PLAN_YEAR = "2026-27";
+
+    @Mock
+    private CassandraOperation cassandraOperation;
+
+    @InjectMocks
+    private CbPlanOrgLookupServiceV3Impl orgLookupService;
+
+    private static ApiResponse cassandraSuccess() {
+        ApiResponse response = new ApiResponse();
+        response.getParams().setStatus(Constants.SUCCESS);
+        response.put(Constants.RESPONSE, Constants.SUCCESS);
+        return response;
+    }
+
+    private static ApiResponse cassandraFailure() {
+        ApiResponse response = new ApiResponse();
+        response.getParams().setStatus(Constants.FAILED);
+        response.getParams().setErr("insert failed");
+        response.put(Constants.RESPONSE, Constants.FAILED);
+        return response;
+    }
+
+    private static Map<String, Object> contextDataWithOrgs(String criteriaKey, List<String> orgIds) {
+        Map<String, Object> criteria = new HashMap<>();
+        criteria.put(Constants.CRITERIA_KEY, criteriaKey);
+        criteria.put(Constants.CRITERIA_VALUE, orgIds);
+        Map<String, Object> userGroup = new HashMap<>();
+        userGroup.put(Constants.USER_GROUP_CRITERIA_LIST, List.of(criteria));
+        Map<String, Object> accessControl = new HashMap<>();
+        accessControl.put(Constants.USER_GROUPS, List.of(userGroup));
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put(Constants.ACCESS_CONTROL, accessControl);
+        return contextData;
+    }
+
+    @Test
+    void testUpsertCustomOrgLookupSuccess() {
+        when(cassandraOperation.insertBulkRecord(anyString(), anyString(), anyList())).thenReturn(cassandraSuccess());
+        ApiResponse response = orgLookupService.upsertCustomOrgLookup(
+                PLAN_ID, PLAN_YEAR, Set.of("org1"), null, true);
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+    }
+
+    @Test
+    void testUpsertCustomOrgLookupBuildsOneRowPerOrgWithEndDate() {
+        when(cassandraOperation.insertBulkRecord(anyString(), anyString(), anyList())).thenReturn(cassandraSuccess());
+        Instant endDate = Instant.parse("2026-12-31T18:29:59Z");
+        orgLookupService.upsertCustomOrgLookup(PLAN_ID, PLAN_YEAR, Set.of("org1", "org2"), endDate, true);
+        ArgumentCaptor<List<Map<String, Object>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(cassandraOperation).insertBulkRecord(
+                eq(Constants.KEYSPACE_SUNBIRD), eq(Constants.TABLE_CB_PLAN_V3_LOOKUP_BY_ORG), captor.capture());
+        List<Map<String, Object>> rows = captor.getValue();
+        assertEquals(2, rows.size());
+        assertEquals(PLAN_YEAR, rows.get(0).get("planyear"));
+        assertEquals(PLAN_ID, rows.get(0).get("planid"));
+        assertEquals(endDate, rows.get(0).get("enddate"));
+        assertEquals(true, rows.get(0).get("isactive"));
+    }
+
+    @Test
+    void testUpsertCustomOrgLookupOmitsEndDateWhenNull() {
+        when(cassandraOperation.insertBulkRecord(anyString(), anyString(), anyList())).thenReturn(cassandraSuccess());
+        orgLookupService.upsertCustomOrgLookup(PLAN_ID, PLAN_YEAR, Set.of("org1"), null, false);
+        ArgumentCaptor<List<Map<String, Object>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(cassandraOperation).insertBulkRecord(anyString(), anyString(), captor.capture());
+        assertTrue(!captor.getValue().get(0).containsKey("enddate"));
+        assertEquals(false, captor.getValue().get(0).get("isactive"));
+    }
+
+    @Test
+    void testUpsertCustomOrgLookupFailsForEmptyOrgList() {
+        ApiResponse response = orgLookupService.upsertCustomOrgLookup(
+                PLAN_ID, PLAN_YEAR, new HashSet<>(), null, true);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        verify(cassandraOperation, never()).insertBulkRecord(anyString(), anyString(), anyList());
+    }
+
+    @Test
+    void testUpsertCustomOrgLookupPropagatesInsertFailure() {
+        when(cassandraOperation.insertBulkRecord(anyString(), anyString(), anyList())).thenReturn(cassandraFailure());
+        ApiResponse response = orgLookupService.upsertCustomOrgLookup(
+                PLAN_ID, PLAN_YEAR, Set.of("org1"), null, true);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+    }
+
+    @Test
+    void testUpsertCustomOrgLookupHandlesException() {
+        when(cassandraOperation.insertBulkRecord(anyString(), anyString(), anyList()))
+                .thenThrow(new RuntimeException("db error"));
+        ApiResponse response = orgLookupService.upsertCustomOrgLookup(
+                PLAN_ID, PLAN_YEAR, Set.of("org1"), null, true);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertTrue(response.getParams().getErr().contains("db error"));
+    }
+
+    @Test
+    void testUpsertAllOrgLookupSuccess() {
+        when(cassandraOperation.insertRecord(anyString(), anyString(), any())).thenReturn(cassandraSuccess());
+        ApiResponse response = orgLookupService.upsertAllOrgLookup(PLAN_ID, PLAN_YEAR, null, true);
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+    }
+
+    @Test
+    void testUpsertAllOrgLookupHandlesException() {
+        when(cassandraOperation.insertRecord(anyString(), anyString(), any()))
+                .thenThrow(new RuntimeException("db error"));
+        ApiResponse response = orgLookupService.upsertAllOrgLookup(PLAN_ID, PLAN_YEAR, null, true);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(Constants.FAILED, response.get(Constants.RESPONSE));
+    }
+
+    @Test
+    void testHandleOrgLookupChangesNoopWhenExistingEmpty() {
+        ApiResponse response = new ApiResponse();
+        orgLookupService.handleOrgLookupChanges(PLAN_ID, PLAN_YEAR, new HashSet<>(), Set.of("org1"),
+                Constants.CUSTOM, response);
+        verify(cassandraOperation, never()).insertBulkRecord(anyString(), anyString(), anyList());
+        assertNotEquals(Constants.FAILED, response.getParams().getStatus());
+    }
+
+    @Test
+    void testHandleOrgLookupChangesNoopWhenNewEmpty() {
+        ApiResponse response = new ApiResponse();
+        orgLookupService.handleOrgLookupChanges(PLAN_ID, PLAN_YEAR, Set.of("org1"), new HashSet<>(),
+                Constants.CUSTOM, response);
+        verify(cassandraOperation, never()).insertBulkRecord(anyString(), anyString(), anyList());
+    }
+
+    @Test
+    void testHandleOrgLookupChangesDeactivatesRemovedOrgsForCustomScope() {
+        when(cassandraOperation.insertBulkRecord(anyString(), anyString(), anyList())).thenReturn(cassandraSuccess());
+        ApiResponse response = new ApiResponse();
+        orgLookupService.handleOrgLookupChanges(PLAN_ID, PLAN_YEAR, Set.of("org1", "org2"), Set.of("org1"),
+                Constants.CUSTOM, response);
+        ArgumentCaptor<List<Map<String, Object>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(cassandraOperation).insertBulkRecord(anyString(), anyString(), captor.capture());
+        assertEquals(1, captor.getValue().size());
+        assertEquals("org2", captor.getValue().get(0).get("orgid"));
+        assertEquals(false, captor.getValue().get(0).get("isactive"));
+    }
+
+    @Test
+    void testHandleOrgLookupChangesReportsFailureOnRemovalError() {
+        when(cassandraOperation.insertBulkRecord(anyString(), anyString(), anyList())).thenReturn(cassandraFailure());
+        ApiResponse response = new ApiResponse();
+        orgLookupService.handleOrgLookupChanges(PLAN_ID, PLAN_YEAR, Set.of("org1", "org2"), Set.of("org1"),
+                Constants.SINGLE, response);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    @Test
+    void testHandleOrgLookupChangesDeactivatesAllScopeWhenOrgsAdded() {
+        when(cassandraOperation.insertRecord(anyString(), anyString(), any())).thenReturn(cassandraSuccess());
+        ApiResponse response = new ApiResponse();
+        orgLookupService.handleOrgLookupChanges(PLAN_ID, PLAN_YEAR, Set.of("org1"), Set.of("org1", "org2"),
+                Constants.ALL, response);
+        verify(cassandraOperation).insertRecord(anyString(), anyString(), any());
+        assertNotEquals(Constants.FAILED, response.getParams().getStatus());
+    }
+
+    @Test
+    void testDeactivateOrgLookupEntriesForSingleScope() {
+        when(cassandraOperation.insertBulkRecord(anyString(), anyString(), anyList())).thenReturn(cassandraSuccess());
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.ORG_SCOPE, Constants.SINGLE);
+        existingCbPlan.put(Constants.CONTEXT_DATA_REQUEST,
+                contextDataWithOrgs(Constants.ROOT_ORG_ID, List.of("org1")));
+        ApiResponse response = new ApiResponse();
+        orgLookupService.deactivateOrgLookupEntries(PLAN_ID, PLAN_YEAR, existingCbPlan, response);
+        verify(cassandraOperation).insertBulkRecord(anyString(), anyString(), anyList());
+        assertNotEquals(Constants.FAILED, response.getParams().getStatus());
+    }
+
+    @Test
+    void testDeactivateOrgLookupEntriesForAllScope() {
+        when(cassandraOperation.insertRecord(anyString(), anyString(), any())).thenReturn(cassandraSuccess());
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.ORG_SCOPE, Constants.ALL);
+        ApiResponse response = new ApiResponse();
+        orgLookupService.deactivateOrgLookupEntries(PLAN_ID, PLAN_YEAR, existingCbPlan, response);
+        verify(cassandraOperation).insertRecord(anyString(), anyString(), any());
+    }
+
+    @Test
+    void testDeactivateOrgLookupEntriesSkipsUnknownScope() {
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.ORG_SCOPE, "UnknownScope");
+        ApiResponse response = new ApiResponse();
+        orgLookupService.deactivateOrgLookupEntries(PLAN_ID, PLAN_YEAR, existingCbPlan, response);
+        verify(cassandraOperation, never()).insertBulkRecord(anyString(), anyString(), anyList());
+        verify(cassandraOperation, never()).insertRecord(anyString(), anyString(), any());
+    }
+
+    @Test
+    void testExtractUniqueRootOrgIdsReturnsEmptyForMissingContextData() {
+        assertTrue(orgLookupService.extractUniqueRootOrgIds(new HashMap<>()).isEmpty());
+    }
+
+    @Test
+    void testExtractUniqueRootOrgIdsFromMapContextData() {
+        Map<String, Object> rawRequest = new HashMap<>();
+        rawRequest.put(Constants.CONTEXT_DATA_REQUEST,
+                contextDataWithOrgs(Constants.TARGETED_ORGANISATION, List.of("org1", "org2")));
+        assertEquals(Set.of("org1", "org2"), orgLookupService.extractUniqueRootOrgIds(rawRequest));
+    }
+
+    @Test
+    void testExtractUniqueRootOrgIdsFromStringContextData() {
+        Map<String, Object> rawRequest = new HashMap<>();
+        rawRequest.put(Constants.CONTEXT_DATA_REQUEST,
+                "{\"accessControl\":{\"userGroups\":[{\"userGroupCriteriaList\":"
+                        + "[{\"criteriaKey\":\"rootOrgId\",\"criteriaValue\":[\"org1\"]}]}]}}");
+        assertEquals(Set.of("org1"), orgLookupService.extractUniqueRootOrgIds(rawRequest));
+    }
+
+    @Test
+    void testExtractUniqueRootOrgIdsReturnsEmptyForMalformedJson() {
+        Map<String, Object> rawRequest = new HashMap<>();
+        rawRequest.put(Constants.CONTEXT_DATA_REQUEST, "not-valid-json");
+        assertTrue(orgLookupService.extractUniqueRootOrgIds(rawRequest).isEmpty());
+    }
+
+    @Test
+    void testExtractUniqueRootOrgIdsReturnsEmptyForUnsupportedType() {
+        Map<String, Object> rawRequest = new HashMap<>();
+        rawRequest.put(Constants.CONTEXT_DATA_REQUEST, 12345);
+        assertTrue(orgLookupService.extractUniqueRootOrgIds(rawRequest).isEmpty());
+    }
+
+    @Test
+    void testExtractOrgIdsFromCriteriaCollectsRootOrgId() {
+        Map<String, Object> criteria = new HashMap<>();
+        criteria.put(Constants.CRITERIA_KEY, Constants.ROOT_ORG_ID);
+        criteria.put(Constants.CRITERIA_VALUE, List.of("org1"));
+        Set<String> orgIdSet = new HashSet<>();
+        orgLookupService.extractOrgIdsFromCriteria(List.of(criteria), orgIdSet);
+        assertEquals(Set.of("org1"), orgIdSet);
+    }
+
+    @Test
+    void testExtractOrgIdsFromCriteriaIgnoresUnrelatedKeys() {
+        Map<String, Object> criteria = new HashMap<>();
+        criteria.put(Constants.CRITERIA_KEY, Constants.DESIGNATION);
+        criteria.put(Constants.CRITERIA_VALUE, List.of("Manager"));
+        Set<String> orgIdSet = new HashSet<>();
+        orgLookupService.extractOrgIdsFromCriteria(List.of(criteria), orgIdSet);
+        assertTrue(orgIdSet.isEmpty());
+    }
+
+    @Test
+    void testExtractOrgIdsFromCriteriaIgnoresEmptyValues() {
+        Map<String, Object> criteria = new HashMap<>();
+        criteria.put(Constants.CRITERIA_KEY, Constants.ROOT_ORG_ID);
+        criteria.put(Constants.CRITERIA_VALUE, List.of());
+        Set<String> orgIdSet = new HashSet<>();
+        orgLookupService.extractOrgIdsFromCriteria(List.of(criteria), orgIdSet);
+        assertTrue(orgIdSet.isEmpty());
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanOrgLookupServiceV3Impl(cassandraOperation));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanServiceV3ImplTest.java
@@ -1,0 +1,919 @@
+package com.igot.cb.cbplan.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.igot.cb.cache.CbPlanCacheMgrV3;
+import com.igot.cb.cache.RedisCacheMgr;
+import com.igot.cb.cassandra.CassandraOperation;
+import com.igot.cb.cbplan.dto.CbPlanContentOccurrence;
+import com.igot.cb.cbplan.dto.CbPlanDictionaryCacheEntry;
+import com.igot.cb.cbplan.dto.CbPlanReadResponseDto;
+import com.igot.cb.elasticsearch.dto.SearchCriteria;
+import com.igot.cb.elasticsearch.dto.SearchResult;
+import com.igot.cb.elasticsearch.service.EsUtilService;
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.service.ContentInfoServiceImpl;
+import com.igot.cb.service.OutboundRequestHandlerServiceImpl;
+import com.igot.cb.service.UserAndOrgServiceImpl;
+import com.igot.cb.util.AccessTokenValidator;
+import com.igot.cb.util.CbExtServerProperties;
+import com.igot.cb.util.Constants;
+import com.igot.cb.util.RequestValidator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanServiceV3ImplTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private static final String TOKEN = "token";
+    private static final String USER_ID = "user1";
+    private static final String ORG_ID = "org1";
+    private static final String PLAN_ID = "plan1";
+    private static final String PLAN_YEAR = "2026-27";
+    private static final String DICT_CACHE_KEY = Constants.CB_PLAN_REDIS_KEY_PREFIX + USER_ID + ":" + PLAN_YEAR + ":dict";
+    private static final String BASIC_PROFILE_CACHE_KEY = Constants.USER + ":basicProfile:" + USER_ID;
+
+    @Mock
+    private AccessTokenValidator accessTokenValidator;
+
+    @Mock
+    private CassandraOperation cassandraOperation;
+
+    @Mock
+    private CbExtServerProperties serverProperties;
+
+    @Mock
+    private UserAndOrgServiceImpl userAndOrgService;
+
+    @Mock
+    private EsUtilService esUtilService;
+
+    @Mock
+    private RequestValidator requestValidator;
+
+    @Mock
+    private ContentInfoServiceImpl contentService;
+
+    @Mock
+    private OutboundRequestHandlerServiceImpl outboundRequestHandlerService;
+
+    @Mock
+    private CbPlanCacheMgrV3 cbPlanCacheMgrV3;
+
+    @Mock
+    private RedisCacheMgr redisCacheMgr;
+
+    @InjectMocks
+    private CbPlanServiceV3Impl cbPlanService;
+
+    private static ApiRequest apiRequest(Map<String, Object> requestMap) {
+        ApiRequest request = new ApiRequest();
+        request.setRequest(requestMap);
+        return request;
+    }
+
+    private static ApiRequest requestWithPlanId() {
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.ID, PLAN_ID);
+        return apiRequest(requestMap);
+    }
+
+    private static ApiResponse cassandraInsertSuccess() {
+        ApiResponse response = new ApiResponse();
+        response.getParams().setStatus(Constants.SUCCESS);
+        response.put(Constants.RESPONSE, Constants.SUCCESS);
+        return response;
+    }
+
+    private void mockAuthenticatedUser() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn(USER_ID);
+    }
+
+    private void mockValidUserAndOrg(boolean isCCA) {
+        mockAuthenticatedUser();
+        Map<String, Object> userMap = new HashMap<>();
+        userMap.put(Constants.ROOT_ORG_ID, ORG_ID);
+        when(userAndOrgService.readUserProfileFromDB(anyString(), anyList())).thenReturn(userMap);
+        Map<String, Object> orgMap = new HashMap<>();
+        orgMap.put(Constants.IS_CCA, isCCA);
+        when(userAndOrgService.readOrgFromDB(anyString(), any())).thenReturn(orgMap);
+    }
+
+    private void mockExistingPlan(Map<String, Object> plan) {
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenReturn(List.of(plan));
+    }
+
+    private void mockEsProperties() {
+        when(serverProperties.getCpPlanIndex()).thenReturn("cbplan-index");
+        when(serverProperties.getElasticCbPlanJsonPath()).thenReturn("path.json");
+    }
+
+    // ---------------- createCbPlan ----------------
+
+    @Test
+    void testCreateCbPlanSuccess() {
+        mockValidUserAndOrg(false);
+        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+                .thenReturn(List.of());
+        when(cassandraOperation.insertRecord(anyString(), anyString(), anyMap())).thenReturn(cassandraInsertSuccess());
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.NAME, "planName");
+        ApiResponse response = cbPlanService.createCbPlan(apiRequest(requestMap), ORG_ID, TOKEN);
+        assertEquals(HttpStatus.CREATED, response.getResponseCode());
+        assertEquals(Constants.CREATED, response.getResult().get(Constants.STATUS));
+        assertNotNull(response.getResult().get(Constants.ID));
+    }
+
+    @Test
+    void testCreateCbPlanFailsWhenTokenInvalid() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn(null);
+        ApiResponse response = cbPlanService.createCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN);
+        assertNotNull(response);
+        verify(cassandraOperation, never()).insertRecord(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void testCreateCbPlanFailsWhenUserOrgNotFound() {
+        mockAuthenticatedUser();
+        when(userAndOrgService.readUserProfileFromDB(anyString(), anyList())).thenReturn(new HashMap<>());
+        ApiResponse response = cbPlanService.createCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+        verify(cassandraOperation, never()).insertRecord(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void testCreateCbPlanFailsOnValidationErrors() {
+        mockValidUserAndOrg(false);
+        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+                .thenReturn(List.of("name is required"));
+        ApiResponse response = cbPlanService.createCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        verify(cassandraOperation, never()).insertRecord(anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    void testCreateCbPlanFailsWhenInsertFails() {
+        mockValidUserAndOrg(false);
+        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+                .thenReturn(List.of());
+        ApiResponse insertFailed = new ApiResponse();
+        insertFailed.put(Constants.RESPONSE, Constants.FAILED);
+        insertFailed.getParams().setErr("insert error");
+        when(cassandraOperation.insertRecord(anyString(), anyString(), anyMap())).thenReturn(insertFailed);
+        ApiResponse response = cbPlanService.createCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    @Test
+    void testCreateCbPlanHandlesUnexpectedException() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenThrow(new RuntimeException("boom"));
+        ApiResponse response = cbPlanService.createCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    // ---------------- updateCbPlan ----------------
+
+    @Test
+    void testUpdateCbPlanFailsWhenPlanIdMissing() {
+        mockAuthenticatedUser();
+        ApiResponse response = cbPlanService.updateCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testUpdateCbPlanFailsWhenPlanNotFound() {
+        mockAuthenticatedUser();
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenReturn(List.of());
+        ApiResponse response = cbPlanService.updateCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testUpdateCbPlanFailsWhenUnauthorized() {
+        mockAuthenticatedUser();
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, "otherUser");
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        mockExistingPlan(existingCbPlan);
+        ApiResponse response = cbPlanService.updateCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.FORBIDDEN, response.getResponseCode());
+    }
+
+    @Test
+    void testUpdateCbPlanDraftSuccess() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        mockExistingPlan(existingCbPlan);
+        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+                .thenReturn(List.of());
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(Constants.RESPONSE, Constants.SUCCESS));
+        ApiResponse response = cbPlanService.updateCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.UPDATED, response.getResult().get(Constants.STATUS));
+        assertNotEquals(Constants.FAILED, response.getParams().getStatus());
+    }
+
+    @Test
+    void testUpdateCbPlanDraftFailsOnValidationErrors() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        mockExistingPlan(existingCbPlan);
+        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+                .thenReturn(List.of("invalid field"));
+        ApiResponse response = cbPlanService.updateCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        verify(cassandraOperation, never()).updateRecord(anyString(), anyString(), anyMap(), anyMap());
+    }
+
+    @Test
+    void testUpdateCbPlanDraftFailsWhenCassandraUpdateFails() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        mockExistingPlan(existingCbPlan);
+        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+                .thenReturn(List.of());
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(Constants.RESPONSE, Constants.FAILED));
+        ApiResponse response = cbPlanService.updateCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testUpdateCbPlanLiveSavesAsDraft() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.LIVE);
+        existingCbPlan.put(Constants.PLAN_ID, PLAN_ID);
+        mockExistingPlan(existingCbPlan);
+        when(requestValidator.validateContextData(anyMap(), anyBoolean(), anyString(), any()))
+                .thenReturn(List.of());
+        when(serverProperties.getCbPlanUpdateAllowedFields()).thenReturn(List.of(Constants.NAME));
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(Constants.RESPONSE, Constants.SUCCESS));
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.ID, PLAN_ID);
+        requestMap.put(Constants.NAME, "updatedLiveName");
+        ApiResponse response = cbPlanService.updateCbPlan(apiRequest(requestMap), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.UPDATED, response.getResult().get(Constants.STATUS));
+        assertNotNull(response.getResult().get(Constants.MESSAGE));
+    }
+
+    @Test
+    void testUpdateCbPlanLiveFailsOnContextDataErrors() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.LIVE);
+        mockExistingPlan(existingCbPlan);
+        when(requestValidator.validateContextData(anyMap(), anyBoolean(), anyString(), any()))
+                .thenReturn(List.of("bad context"));
+        ApiResponse response = cbPlanService.updateCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testUpdateCbPlanHandlesUnexpectedException() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenThrow(new RuntimeException("boom"));
+        ApiResponse response = cbPlanService.updateCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    // ---------------- publishCbPlan ----------------
+
+    @Test
+    void testPublishCbPlanFailsWhenPlanIdMissing() {
+        mockAuthenticatedUser();
+        ApiResponse response = cbPlanService.publishCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testPublishCbPlanFailsWhenPlanNotFound() {
+        mockAuthenticatedUser();
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenReturn(List.of());
+        ApiResponse response = cbPlanService.publishCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testPublishCbPlanFailsWhenUnauthorized() {
+        mockAuthenticatedUser();
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, "otherUser");
+        mockExistingPlan(existingCbPlan);
+        ApiResponse response = cbPlanService.publishCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.FORBIDDEN, response.getResponseCode());
+    }
+
+    @Test
+    void testPublishCbPlanFailsForInvalidStatus() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.CB_RETIRE);
+        mockExistingPlan(existingCbPlan);
+        ApiResponse response = cbPlanService.publishCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testPublishCbPlanDraftToLiveSuccess() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        existingCbPlan.put(Constants.ORG_SCOPE, Constants.ALL);
+        existingCbPlan.put(Constants.PLAN_YEAR, PLAN_YEAR);
+        mockExistingPlan(existingCbPlan);
+        when(requestValidator.validateContextData(anyMap(), anyBoolean(), anyString(), any(), anyBoolean()))
+                .thenReturn(List.of());
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap(), any(), any()))
+                .thenReturn(Map.of(Constants.RESPONSE, Constants.SUCCESS));
+        when(cassandraOperation.insertRecord(anyString(), anyString(), anyMap())).thenReturn(cassandraInsertSuccess());
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.ID, PLAN_ID);
+        requestMap.put(Constants.COMMENT, "publishing");
+        ApiResponse response = cbPlanService.publishCbPlan(apiRequest(requestMap), ORG_ID, TOKEN, List.of());
+        assertNotEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+    }
+
+    @Test
+    void testPublishCbPlanDraftFailsOnContextDataErrors() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        mockExistingPlan(existingCbPlan);
+        when(requestValidator.validateContextData(anyMap(), anyBoolean(), anyString(), any(), anyBoolean()))
+                .thenReturn(List.of("bad context"));
+        ApiResponse response = cbPlanService.publishCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testPublishCbPlanFailsWhenCassandraTransactionFails() {
+        mockValidUserAndOrg(false);
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        existingCbPlan.put(Constants.PLAN_YEAR, PLAN_YEAR);
+        mockExistingPlan(existingCbPlan);
+        when(requestValidator.validateContextData(anyMap(), anyBoolean(), anyString(), any(), anyBoolean()))
+                .thenReturn(List.of());
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap(), any(), any()))
+                .thenReturn(Map.of(Constants.RESPONSE, Constants.FAILED, Constants.ERROR_MESSAGE, "commit failed"));
+        ApiResponse response = cbPlanService.publishCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    @Test
+    void testPublishCbPlanHandlesUnexpectedException() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenThrow(new RuntimeException("boom"));
+        ApiResponse response = cbPlanService.publishCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    // ---------------- retireCbPlan ----------------
+
+    @Test
+    void testRetireCbPlanFailsWhenPlanIdMissing() {
+        mockAuthenticatedUser();
+        ApiResponse response = cbPlanService.retireCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testRetireCbPlanFailsWhenPlanIdBlank() {
+        mockAuthenticatedUser();
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.ID, "   ");
+        ApiResponse response = cbPlanService.retireCbPlan(apiRequest(requestMap), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testRetireCbPlanFailsWhenPlanNotFound() {
+        mockAuthenticatedUser();
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenReturn(List.of());
+        ApiResponse response = cbPlanService.retireCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testRetireCbPlanFailsWhenUnauthorized() {
+        mockAuthenticatedUser();
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, "otherUser");
+        mockExistingPlan(existingCbPlan);
+        ApiResponse response = cbPlanService.retireCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(HttpStatus.FORBIDDEN, response.getResponseCode());
+    }
+
+    @Test
+    void testRetireCbPlanFailsWhenAlreadyArchived() {
+        mockAuthenticatedUser();
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.CB_RETIRE);
+        mockExistingPlan(existingCbPlan);
+        ApiResponse response = cbPlanService.retireCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testRetireCbPlanSuccess() {
+        mockAuthenticatedUser();
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        existingCbPlan.put(Constants.ORG_SCOPE, Constants.ALL);
+        existingCbPlan.put(Constants.PLAN_YEAR, PLAN_YEAR);
+        mockExistingPlan(existingCbPlan);
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(Constants.RESPONSE, Constants.SUCCESS));
+        when(cassandraOperation.insertRecord(anyString(), anyString(), anyMap())).thenReturn(cassandraInsertSuccess());
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put(Constants.ID, PLAN_ID);
+        requestMap.put(Constants.COMMENT, "archiving");
+        ApiResponse response = cbPlanService.retireCbPlan(apiRequest(requestMap), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.UPDATED, response.getResult().get(Constants.STATUS));
+        assertNotEquals(Constants.FAILED, response.getParams().getStatus());
+    }
+
+    @Test
+    void testRetireCbPlanFailsWhenCassandraUpdateFails() {
+        mockAuthenticatedUser();
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
+        mockExistingPlan(existingCbPlan);
+        when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
+                .thenReturn(Map.of(Constants.RESPONSE, Constants.FAILED, Constants.ERROR_MESSAGE, "update failed"));
+        ApiResponse response = cbPlanService.retireCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testRetireCbPlanHandlesUnexpectedException() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenThrow(new RuntimeException("boom"));
+        ApiResponse response = cbPlanService.retireCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    // ---------------- searchCbPlan ----------------
+
+    @Test
+    void testSearchCbPlanSuccess() throws Exception {
+        mockAuthenticatedUser();
+        mockEsProperties();
+        Map<String, Object> item = new HashMap<>();
+        item.put(Constants.ID, PLAN_ID);
+        SearchResult searchResult = new SearchResult(
+                new ArrayList<>(List.of(item)), new HashMap<>(), 1L, new ArrayList<>());
+        when(esUtilService.searchDocuments(anyString(), any(SearchCriteria.class), anyString()))
+                .thenReturn(searchResult);
+        ApiResponse response = cbPlanService.searchCbPlan(new SearchCriteria(), ORG_ID, TOKEN);
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        assertNotNull(response.getResult().get(Constants.RESULT));
+    }
+
+    @Test
+    void testSearchCbPlanWithEmptyResultsDoesNotPopulateResult() throws Exception {
+        mockAuthenticatedUser();
+        mockEsProperties();
+        SearchResult searchResult = new SearchResult(new ArrayList<>(), new HashMap<>(), 0L, new ArrayList<>());
+        when(esUtilService.searchDocuments(anyString(), any(SearchCriteria.class), anyString()))
+                .thenReturn(searchResult);
+        ApiResponse response = cbPlanService.searchCbPlan(new SearchCriteria(), ORG_ID, TOKEN);
+        assertFalse(response.getResult().containsKey(Constants.RESULT));
+        assertNotEquals(Constants.FAILED, response.getParams().getStatus());
+    }
+
+    @Test
+    void testSearchCbPlanFailsWhenTokenInvalid() throws Exception {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn(null);
+        cbPlanService.searchCbPlan(new SearchCriteria(), ORG_ID, TOKEN);
+        verify(esUtilService, never()).searchDocuments(anyString(), any(), anyString());
+    }
+
+    @Test
+    void testSearchCbPlanHandlesElasticSearchException() throws Exception {
+        mockAuthenticatedUser();
+        mockEsProperties();
+        when(esUtilService.searchDocuments(anyString(), any(SearchCriteria.class), anyString()))
+                .thenThrow(new RuntimeException("es down"));
+        ApiResponse response = cbPlanService.searchCbPlan(new SearchCriteria(), ORG_ID, TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    // ---------------- readCbPlan ----------------
+
+    @Test
+    void testReadCbPlanFailsWhenIdMissing() {
+        ApiResponse response = cbPlanService.readCbPlan("", ORG_ID, TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testReadCbPlanFailsWhenPlanNotFound() {
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenReturn(List.of());
+        ApiResponse response = cbPlanService.readCbPlan(PLAN_ID, ORG_ID, TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        assertTrue(response.getParams().getErr().contains(PLAN_ID));
+    }
+
+    @Test
+    void testReadCbPlanReturnsDirectFieldsWhenNoDraftData() {
+        Instant endDate = Instant.parse("2026-12-31T18:29:59Z");
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.NAME, "planName");
+        plan.put(Constants.STATUS, Constants.DRAFT);
+        plan.put(Constants.PLAN_YEAR, PLAN_YEAR);
+        plan.put(Constants.END_DATE_REQUEST, endDate);
+        plan.put(Constants.IS_APAR, true);
+        plan.put(Constants.CONTENT_LIST, List.of("course1"));
+        plan.put(Constants.CREATED_BY, USER_ID);
+        mockExistingPlan(plan);
+        List<Map<String, Object>> enriched = List.of(Map.of("identifier", "course1"));
+        when(contentService.enrichContentInfoForCBPlan(anyList())).thenReturn(enriched);
+        ApiResponse response = cbPlanService.readCbPlan(PLAN_ID, ORG_ID, TOKEN);
+        CbPlanReadResponseDto dto = (CbPlanReadResponseDto) response.getResult().get(Constants.CONTENT);
+        assertEquals(PLAN_ID, dto.getId());
+        assertEquals("planName", dto.getName());
+        assertEquals(PLAN_YEAR, dto.getPlanYear());
+        assertEquals(endDate, dto.getEndDate());
+        assertTrue(dto.getIsApar());
+        assertEquals(Constants.DRAFT, dto.getStatus());
+        assertEquals(USER_ID, dto.getCreatedBy());
+        assertEquals(enriched, dto.getContentList());
+    }
+
+    @Test
+    void testReadCbPlanPrefersDraftDataForLivePlan() {
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.NAME, "liveName");
+        plan.put(Constants.STATUS, Constants.LIVE);
+        plan.put(Constants.PLAN_YEAR, PLAN_YEAR);
+        plan.put(Constants.CONTENT_LIST, List.of("courseLive"));
+        plan.put(Constants.DRAFT_DATA,
+                "{\"name\":\"draftName\",\"contentList\":[\"courseDraft\"],\"isApar\":true,\"endDate\":\"2026-12-31\"}");
+        mockExistingPlan(plan);
+        when(contentService.enrichContentInfoForCBPlan(anyList())).thenReturn(List.of());
+        ApiResponse response = cbPlanService.readCbPlan(PLAN_ID, ORG_ID, TOKEN);
+        CbPlanReadResponseDto dto = (CbPlanReadResponseDto) response.getResult().get(Constants.CONTENT);
+        assertEquals("draftName", dto.getName());
+        assertTrue(dto.getIsApar());
+        assertNotNull(dto.getEndDate());
+        verify(contentService).enrichContentInfoForCBPlan(List.of("courseDraft"));
+    }
+
+    @Test
+    void testReadCbPlanIgnoresEmptyDraftDataObject() {
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.NAME, "liveName");
+        plan.put(Constants.STATUS, Constants.LIVE);
+        plan.put(Constants.DRAFT_DATA, "{}");
+        plan.put(Constants.CONTENT_LIST, List.of("courseLive"));
+        mockExistingPlan(plan);
+        when(contentService.enrichContentInfoForCBPlan(anyList())).thenReturn(List.of());
+        ApiResponse response = cbPlanService.readCbPlan(PLAN_ID, ORG_ID, TOKEN);
+        CbPlanReadResponseDto dto = (CbPlanReadResponseDto) response.getResult().get(Constants.CONTENT);
+        assertEquals("liveName", dto.getName());
+        verify(contentService).enrichContentInfoForCBPlan(List.of("courseLive"));
+    }
+
+    @Test
+    void testReadCbPlanParsesContextDataIntoJsonNode() {
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.STATUS, Constants.DRAFT);
+        plan.put(Constants.CONTEXT_DATA_REQUEST, "{\"accessControl\":{\"userGroups\":[]}}");
+        mockExistingPlan(plan);
+        when(contentService.enrichContentInfoForCBPlan(anyList())).thenReturn(List.of());
+        ApiResponse response = cbPlanService.readCbPlan(PLAN_ID, ORG_ID, TOKEN);
+        CbPlanReadResponseDto dto = (CbPlanReadResponseDto) response.getResult().get(Constants.CONTENT);
+        assertNotNull(dto.getContextData());
+        assertTrue(dto.getContextData().has("accessControl"));
+    }
+
+    @Test
+    void testReadCbPlanReturnsNullContextDataForMalformedJson() {
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.STATUS, Constants.DRAFT);
+        plan.put(Constants.CONTEXT_DATA_REQUEST, "not-valid-json");
+        mockExistingPlan(plan);
+        when(contentService.enrichContentInfoForCBPlan(anyList())).thenReturn(List.of());
+        ApiResponse response = cbPlanService.readCbPlan(PLAN_ID, ORG_ID, TOKEN);
+        CbPlanReadResponseDto dto = (CbPlanReadResponseDto) response.getResult().get(Constants.CONTENT);
+        assertNotNull(dto);
+        assertEquals(null, dto.getContextData());
+    }
+
+    @Test
+    void testReadCbPlanHandlesUnexpectedException() {
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenThrow(new RuntimeException("db down"));
+        ApiResponse response = cbPlanService.readCbPlan(PLAN_ID, ORG_ID, TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    // ---------------- getCBPlanDictionaryForUser ----------------
+
+    @Test
+    void testGetCBPlanDictionaryFailsWhenTokenInvalid() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("");
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(new HashMap<>()), TOKEN);
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getResponseCode());
+    }
+
+    @Test
+    void testGetCBPlanDictionaryFailsForInvalidPlanYear() {
+        mockAuthenticatedUser();
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", "invalid-year");
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testGetCBPlanDictionaryReturnsCachedEntryOnRedisHit() throws Exception {
+        mockAuthenticatedUser();
+        Map<String, List<CbPlanContentOccurrence>> aparMap = new LinkedHashMap<>();
+        aparMap.put("course1", List.of(new CbPlanContentOccurrence(PLAN_ID, Instant.EPOCH)));
+        CbPlanDictionaryCacheEntry cacheEntry =
+                new CbPlanDictionaryCacheEntry(aparMap, new LinkedHashMap<>(), 1, 0);
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(MAPPER.writeValueAsString(cacheEntry));
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        assertEquals(1, response.getResult().get("aparCount"));
+        verify(cbPlanCacheMgrV3, never()).getCbPlanForAllAndOrgId(anyString(), anyString(), any());
+        verify(cassandraOperation, never()).getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any());
+    }
+
+    @Test
+    void testGetCBPlanDictionaryFailsWhenUserNotFound() {
+        mockAuthenticatedUser();
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(null);
+        when(redisCacheMgr.getFromCache(BASIC_PROFILE_CACHE_KEY)).thenReturn(null);
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenReturn(List.of());
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testGetCBPlanDictionaryUsesBasicProfileRedisCacheOnCacheMiss() {
+        mockAuthenticatedUser();
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(null);
+        when(redisCacheMgr.getFromCache(BASIC_PROFILE_CACHE_KEY))
+                .thenReturn("{\"id\":\"" + USER_ID + "\",\"rootOrgId\":\"" + ORG_ID + "\"}");
+        when(cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(anyString(), anyString(), any())).thenReturn(List.of());
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        verify(cassandraOperation, never()).getRecordsByProperties(
+                anyString(), eq(Constants.USER), anyMap(), any(), any());
+        verify(cbPlanCacheMgrV3).getCbPlanForAllAndOrgId(eq(ORG_ID), eq(PLAN_YEAR), any());
+    }
+
+    @Test
+    void testGetCBPlanDictionaryReturnsEmptyWhenNoActivePlans() {
+        mockAuthenticatedUser();
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(null);
+        when(redisCacheMgr.getFromCache(BASIC_PROFILE_CACHE_KEY))
+                .thenReturn("{\"id\":\"" + USER_ID + "\",\"rootOrgId\":\"" + ORG_ID + "\"}");
+        when(cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(anyString(), anyString(), any())).thenReturn(List.of());
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        assertEquals(0, response.getResult().get("aparCount"));
+        assertEquals(0, response.getResult().get("nonAparCount"));
+        verify(redisCacheMgr).putInCache(eq(DICT_CACHE_KEY), anyString(), anyInt());
+    }
+
+    @Test
+    void testGetCBPlanDictionaryGroupsAparContent() {
+        mockAuthenticatedUser();
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(null);
+        when(redisCacheMgr.getFromCache(BASIC_PROFILE_CACHE_KEY))
+                .thenReturn("{\"id\":\"" + USER_ID + "\",\"rootOrgId\":\"" + ORG_ID + "\"}");
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.PLAN_ID, PLAN_ID);
+        plan.put(Constants.END_DATE_KEY, Instant.now());
+        plan.put(Constants.IS_APAR, true);
+        plan.put(Constants.CONTENT_LIST, List.of("course1"));
+        when(cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(anyString(), anyString(), any())).thenReturn(List.of(plan));
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(Constants.SUCCESS, response.getParams().getStatus());
+        assertEquals(1, response.getResult().get("aparCount"));
+        assertEquals(0, response.getResult().get("nonAparCount"));
+        Map<String, Object> aparContentList = (Map<String, Object>) response.getResult().get("aparContentList");
+        assertTrue(aparContentList.containsKey("course1"));
+    }
+
+    @Test
+    void testGetCBPlanDictionaryGroupsNonAparContent() {
+        mockAuthenticatedUser();
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(null);
+        when(redisCacheMgr.getFromCache(BASIC_PROFILE_CACHE_KEY))
+                .thenReturn("{\"id\":\"" + USER_ID + "\",\"rootOrgId\":\"" + ORG_ID + "\"}");
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.PLAN_ID, PLAN_ID);
+        plan.put(Constants.END_DATE_KEY, Instant.now());
+        plan.put(Constants.IS_APAR, false);
+        plan.put(Constants.CONTENT_LIST, List.of("course1"));
+        when(cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(anyString(), anyString(), any())).thenReturn(List.of(plan));
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(0, response.getResult().get("aparCount"));
+        assertEquals(1, response.getResult().get("nonAparCount"));
+    }
+
+    @Test
+    void testGetCBPlanDictionarySkipsPlansWithEmptyContentList() {
+        mockAuthenticatedUser();
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(null);
+        when(redisCacheMgr.getFromCache(BASIC_PROFILE_CACHE_KEY))
+                .thenReturn("{\"id\":\"" + USER_ID + "\",\"rootOrgId\":\"" + ORG_ID + "\"}");
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.PLAN_ID, PLAN_ID);
+        plan.put(Constants.IS_APAR, false);
+        plan.put(Constants.CONTENT_LIST, List.of());
+        when(cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(anyString(), anyString(), any())).thenReturn(List.of(plan));
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(0, response.getResult().get("aparCount"));
+        assertEquals(0, response.getResult().get("nonAparCount"));
+    }
+
+    @Test
+    void testGetCBPlanDictionaryDeniesAccessWhenContextCriteriaDoNotMatch() {
+        mockAuthenticatedUser();
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(null);
+        when(redisCacheMgr.getFromCache(BASIC_PROFILE_CACHE_KEY))
+                .thenReturn("{\"id\":\"" + USER_ID + "\",\"rootOrgId\":\"" + ORG_ID + "\"}");
+        Map<String, Object> plan = new HashMap<>();
+        plan.put(Constants.PLAN_ID, PLAN_ID);
+        plan.put(Constants.IS_APAR, false);
+        plan.put(Constants.CONTENT_LIST, List.of("course1"));
+        plan.put(Constants.CONTEXT_DATA_REQUEST,
+                "{\"accessControl\":{\"userGroups\":[{\"userGroupCriteriaList\":"
+                        + "[{\"criteriaKey\":\"designation\",\"criteriaValue\":[\"Director\"]}]}]}}");
+        when(cbPlanCacheMgrV3.getCbPlanForAllAndOrgId(anyString(), anyString(), any())).thenReturn(List.of(plan));
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertEquals(0, response.getResult().get("nonAparCount"));
+    }
+
+    @Test
+    void testGetCBPlanDictionaryEnrichesContentWhenRequested() throws Exception {
+        mockAuthenticatedUser();
+        Map<String, List<CbPlanContentOccurrence>> nonAparMap = new LinkedHashMap<>();
+        nonAparMap.put("course1", List.of(new CbPlanContentOccurrence(PLAN_ID, Instant.EPOCH)));
+        CbPlanDictionaryCacheEntry cacheEntry =
+                new CbPlanDictionaryCacheEntry(new LinkedHashMap<>(), nonAparMap, 0, 1);
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(MAPPER.writeValueAsString(cacheEntry));
+        when(redisCacheMgr.getFromCache(Constants.EXTENDED_READ_CONTENT_CACHE_KEY_PREFIX + "course1"))
+                .thenReturn("{\"identifier\":\"course1\",\"name\":\"Course 1\"}");
+        when(serverProperties.getCbPlanEnrichedContentFieldsList()).thenReturn(List.of("identifier", "name"));
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        requestMap.put("enrichment", true);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        Map<String, Object> enriched = (Map<String, Object>) response.getResult().get("enrichedContentList");
+        assertNotNull(enriched);
+        Map<String, Object> courseDetails = (Map<String, Object>) enriched.get("course1");
+        assertEquals("Course 1", courseDetails.get("name"));
+        assertFalse(courseDetails.containsKey("_fromCache"));
+    }
+
+    @Test
+    void testGetCBPlanDictionaryOmitsEnrichedListWhenNotRequested() throws Exception {
+        mockAuthenticatedUser();
+        CbPlanDictionaryCacheEntry cacheEntry =
+                new CbPlanDictionaryCacheEntry(new LinkedHashMap<>(), new LinkedHashMap<>(), 0, 0);
+        when(redisCacheMgr.getFromCache(DICT_CACHE_KEY)).thenReturn(MAPPER.writeValueAsString(cacheEntry));
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("planYear", PLAN_YEAR);
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(requestMap), TOKEN);
+        assertFalse(response.getResult().containsKey("enrichedContentList"));
+    }
+
+    @Test
+    void testGetCBPlanDictionaryHandlesNullRequestBody() {
+        mockAuthenticatedUser();
+        when(redisCacheMgr.getFromCache(anyString())).thenReturn(null);
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), any(), any()))
+                .thenReturn(List.of());
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(null), TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testGetCBPlanDictionaryHandlesUnexpectedException() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any()))
+                .thenThrow(new RuntimeException("boom"));
+        ApiResponse response = cbPlanService.getCBPlanDictionaryForUser(apiRequest(new HashMap<>()), TOKEN);
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanServiceV3Impl(accessTokenValidator, cassandraOperation, serverProperties,
+                userAndOrgService, esUtilService, requestValidator, contentService,
+                outboundRequestHandlerService, cbPlanCacheMgrV3, redisCacheMgr));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanValidationServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanValidationServiceV3ImplTest.java
@@ -1,0 +1,276 @@
+package com.igot.cb.cbplan.service.impl;
+
+import com.igot.cb.model.ApiRequest;
+import com.igot.cb.model.ApiResponse;
+import com.igot.cb.service.UserAndOrgServiceImpl;
+import com.igot.cb.util.AccessTokenValidator;
+import com.igot.cb.util.Constants;
+import com.igot.cb.util.RequestValidator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbPlanValidationServiceV3ImplTest {
+
+    private static final String USER_ID = "user1";
+    private static final String ORG_ID = "org1";
+    private static final String PLAN_ID = "plan123";
+
+    @Mock
+    private AccessTokenValidator accessTokenValidator;
+
+    @Mock
+    private UserAndOrgServiceImpl userAndOrgService;
+
+    @Mock
+    private RequestValidator requestValidator;
+
+    @InjectMocks
+    private CbPlanValidationServiceV3Impl validationService;
+
+    private static ApiRequest apiRequestWithId(String planId) {
+        ApiRequest request = new ApiRequest();
+        Map<String, Object> requestMap = new HashMap<>();
+        if (planId != null) {
+            requestMap.put(Constants.ID, planId);
+        }
+        request.setRequest(requestMap);
+        return request;
+    }
+
+    @Test
+    void testValidateAndExtractUserIdSuccess() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn(USER_ID);
+        assertEquals(USER_ID, validationService.validateAndExtractUserId("token", new ApiResponse()));
+    }
+
+    @Test
+    void testValidateAndExtractUserIdReturnsNullWhenBlank() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn("");
+        assertNull(validationService.validateAndExtractUserId("token", new ApiResponse()));
+    }
+
+    @Test
+    void testValidateAndExtractUserIdReturnsNullWhenNull() {
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString(), any())).thenReturn(null);
+        assertNull(validationService.validateAndExtractUserId("token", new ApiResponse()));
+    }
+
+    @Test
+    void testValidateUserOrganizationSuccess() {
+        Map<String, Object> userMap = new HashMap<>();
+        userMap.put(Constants.ROOT_ORG_ID, ORG_ID);
+        when(userAndOrgService.readUserProfileFromDB(anyString(), anyList())).thenReturn(userMap);
+        assertEquals(ORG_ID, validationService.validateUserOrganization(USER_ID, new ApiResponse()));
+    }
+
+    @Test
+    void testValidateUserOrganizationFailsWhenUserNotFound() {
+        ApiResponse response = new ApiResponse();
+        when(userAndOrgService.readUserProfileFromDB(anyString(), anyList())).thenReturn(new HashMap<>());
+        assertNull(validationService.validateUserOrganization(USER_ID, response));
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    @Test
+    void testValidateOrgCCAReturnsTrue() {
+        Map<String, Object> orgMap = new HashMap<>();
+        orgMap.put(Constants.IS_CCA, "true");
+        when(userAndOrgService.readOrgFromDB(anyString(), any())).thenReturn(orgMap);
+        assertTrue(validationService.validateOrgCCA(ORG_ID, new ApiResponse()));
+    }
+
+    @Test
+    void testValidateOrgCCAReturnsFalseWhenFlagFalse() {
+        Map<String, Object> orgMap = new HashMap<>();
+        orgMap.put(Constants.IS_CCA, false);
+        when(userAndOrgService.readOrgFromDB(anyString(), any())).thenReturn(orgMap);
+        assertFalse(validationService.validateOrgCCA(ORG_ID, new ApiResponse()));
+    }
+
+    @Test
+    void testValidateOrgCCAFailsWhenOrgNotFound() {
+        ApiResponse response = new ApiResponse();
+        when(userAndOrgService.readOrgFromDB(anyString(), any())).thenReturn(new HashMap<>());
+        assertFalse(validationService.validateOrgCCA(ORG_ID, response));
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
+    }
+
+    @Test
+    void testValidateOrgCCAReturnsFalseWhenKeyMissing() {
+        Map<String, Object> orgMap = new HashMap<>();
+        orgMap.put(Constants.NAME, "someOrg");
+        when(userAndOrgService.readOrgFromDB(anyString(), any())).thenReturn(orgMap);
+        assertFalse(validationService.validateOrgCCA(ORG_ID, new ApiResponse()));
+    }
+
+    @Test
+    void testValidateRequestPassesWhenNoValidationErrors() {
+        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+                .thenReturn(List.of());
+        assertTrue(validationService.validateRequest(new ApiRequest(), true, ORG_ID, new ApiResponse()));
+    }
+
+    @Test
+    void testValidateRequestFailsWithValidationErrors() {
+        ApiResponse response = new ApiResponse();
+        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+                .thenReturn(List.of("name is required"));
+        assertFalse(validationService.validateRequest(new ApiRequest(), true, ORG_ID, response));
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        assertTrue(response.getParams().getErr().contains("name is required"));
+    }
+
+    @Test
+    void testValidatePlanIdExistsWhenPresent() {
+        assertTrue(validationService.validatePlanIdExists(apiRequestWithId(PLAN_ID), new ApiResponse()));
+    }
+
+    @Test
+    void testValidatePlanIdExistsFailsWhenMissing() {
+        ApiResponse response = new ApiResponse();
+        assertFalse(validationService.validatePlanIdExists(apiRequestWithId(null), response));
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testValidatePlanIdExistsFailsWhenBlank() {
+        ApiResponse response = new ApiResponse();
+        assertFalse(validationService.validatePlanIdExists(apiRequestWithId("  "), response));
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testIsUnauthorizedToUpdateAllowsOwner() {
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, USER_ID);
+        assertFalse(validationService.isUnauthorizedToUpdate(USER_ID, existingCbPlan, List.of(), new ApiResponse()));
+    }
+
+    @Test
+    void testIsUnauthorizedToUpdateAllowsAdmin() {
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, "otherUser");
+        assertFalse(validationService.isUnauthorizedToUpdate(USER_ID, existingCbPlan,
+                List.of(Constants.ROLE_ADMIN), new ApiResponse()));
+    }
+
+    @Test
+    void testIsUnauthorizedToUpdateBlocksNonOwnerNonAdmin() {
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, "otherUser");
+        ApiResponse response = new ApiResponse();
+        assertTrue(validationService.isUnauthorizedToUpdate(USER_ID, existingCbPlan, List.of("PUBLIC"), response));
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.FORBIDDEN, response.getResponseCode());
+    }
+
+    @Test
+    void testIsUnauthorizedToUpdateBlocksWhenRolesNull() {
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.CREATED_BY, "otherUser");
+        ApiResponse response = new ApiResponse();
+        assertTrue(validationService.isUnauthorizedToUpdate(USER_ID, existingCbPlan, null, response));
+        assertEquals(HttpStatus.FORBIDDEN, response.getResponseCode());
+    }
+
+    @Test
+    void testValidateContextDataForLivePlanPasses() {
+        when(requestValidator.validateContextData(any(), anyBoolean(), anyString(), any())).thenReturn(List.of());
+        assertTrue(validationService.validateContextDataForLivePlan(new HashMap<>(), true, ORG_ID,
+                new HashSet<>(), new ApiResponse()));
+    }
+
+    @Test
+    void testValidateContextDataForLivePlanFails() {
+        ApiResponse response = new ApiResponse();
+        when(requestValidator.validateContextData(any(), anyBoolean(), anyString(), any()))
+                .thenReturn(List.of("bad context"));
+        assertFalse(validationService.validateContextDataForLivePlan(new HashMap<>(), true, ORG_ID,
+                new HashSet<>(), response));
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        assertTrue(response.getParams().getErr().contains("bad context"));
+    }
+
+    @Test
+    void testValidateContextDataForLivePlanPopulatesOrgIdsFromValidator() {
+        Set<String> rootOrgIds = new HashSet<>();
+        when(requestValidator.validateContextData(any(), anyBoolean(), anyString(), any()))
+                .thenAnswer(invocation -> {
+                    Set<String> target = invocation.getArgument(3);
+                    target.add(ORG_ID);
+                    return List.of();
+                });
+        assertTrue(validationService.validateContextDataForLivePlan(new HashMap<>(), false, ORG_ID,
+                rootOrgIds, new ApiResponse()));
+        assertEquals(Set.of(ORG_ID), rootOrgIds);
+    }
+
+    @Test
+    void testValidateAndExtractPlanIdWhenPresent() {
+        Map<String, Object> incomingRequest = new HashMap<>();
+        incomingRequest.put(Constants.ID, PLAN_ID);
+        assertEquals(PLAN_ID, validationService.validateAndExtractPlanId(incomingRequest, new ApiResponse()));
+    }
+
+    @Test
+    void testValidateAndExtractPlanIdFailsWhenMissing() {
+        ApiResponse response = new ApiResponse();
+        assertNull(validationService.validateAndExtractPlanId(new HashMap<>(), response));
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testIsAlreadyArchivedReturnsTrueForRetiredPlan() {
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.STATUS, Constants.CB_RETIRE);
+        ApiResponse response = new ApiResponse();
+        assertTrue(validationService.isAlreadyArchived(existingCbPlan, PLAN_ID, response));
+        assertEquals(Constants.FAILED, response.getParams().getStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+    }
+
+    @Test
+    void testIsAlreadyArchivedReturnsFalseForLivePlan() {
+        Map<String, Object> existingCbPlan = new HashMap<>();
+        existingCbPlan.put(Constants.STATUS, Constants.LIVE);
+        assertFalse(validationService.isAlreadyArchived(existingCbPlan, PLAN_ID, new ApiResponse()));
+    }
+
+    @Test
+    void testIsAlreadyArchivedReturnsFalseWhenStatusMissing() {
+        assertFalse(validationService.isAlreadyArchived(new HashMap<>(), PLAN_ID, new ApiResponse()));
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(new CbPlanValidationServiceV3Impl(accessTokenValidator, userAndOrgService, requestValidator));
+    }
+}

--- a/src/test/java/com/igot/cb/cbplan/util/CbPlanYearUtilTest.java
+++ b/src/test/java/com/igot/cb/cbplan/util/CbPlanYearUtilTest.java
@@ -1,0 +1,75 @@
+package com.igot.cb.cbplan.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CbPlanYearUtilTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "2026, 8, 12, 2026-27",
+            "2026, 2, 12, 2025-26",
+            "2026, 4, 1, 2026-27",
+            "2026, 3, 31, 2025-26",
+            "2026, 12, 31, 2026-27",
+            "2026, 1, 1, 2025-26"
+    })
+    void testResolveFinancialYearForDate(int year, int month, int day, String expected) {
+        assertEquals(expected, CbPlanYearUtil.resolveFinancialYearForDate(LocalDate.of(year, month, day)));
+    }
+
+    @Test
+    void testResolveFinancialYearAcrossCenturyBoundary() {
+        assertEquals("2099-00", CbPlanYearUtil.resolveFinancialYearForDate(
+                LocalDate.of(2099, Month.APRIL, 1)));
+    }
+
+    @Test
+    void testResolveCurrentFinancialYearMatchesExpectedFormat() {
+        String currentFy = CbPlanYearUtil.resolveCurrentFinancialYear();
+        assertTrue(currentFy.matches("^\\d{4}-\\d{2}$"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2026-27", "2025-26", "1999-00"})
+    void testIsValidPlanYearFormatAcceptsValidYears(String planYear) {
+        assertTrue(CbPlanYearUtil.isValidPlanYearFormat(planYear));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2026-30", "2026/27", "202-27", "2026-2027", "abcd-ef", "   ", ""})
+    void testIsValidPlanYearFormatRejectsInvalidYears(String planYear) {
+        assertFalse(CbPlanYearUtil.isValidPlanYearFormat(planYear));
+    }
+
+    @Test
+    void testIsValidPlanYearFormatRejectsNull() {
+        assertFalse(CbPlanYearUtil.isValidPlanYearFormat(null));
+    }
+
+    @Test
+    void testValidateAndNormalizeTrimsValidYear() {
+        assertEquals("2026-27", CbPlanYearUtil.validateAndNormalize("  2026-27  "));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid", "2026-30", "  "})
+    void testValidateAndNormalizeReturnsNullForInvalid(String planYear) {
+        assertNull(CbPlanYearUtil.validateAndNormalize(planYear));
+    }
+
+    @Test
+    void testValidateAndNormalizeReturnsNullForNull() {
+        assertNull(CbPlanYearUtil.validateAndNormalize(null));
+    }
+}


### PR DESCRIPTION

Introduces the CB Plan V3 API under a new `com.igot.cb.cbplan` package, alongside the existing V1/V2 controllers. No existing endpoints changed or removed.

### New API — `/cbplan/v3`
Method	Path	Purpose
POST	/create	Create a CB Plan (DRAFT)
POST	/update	Update DRAFT in place; LIVE plans staged into draftData
POST	/publish	Publish DRAFT→LIVE, or re-publish a staged draft
DELETE	/archive	Retire a plan and deactivate its org lookups
GET	/read/{cbPlanId}	Read a plan with enriched content metadata
POST	/search	ES-backed search with createdBy/content enrichment
POST	/user/dictionary	Per-user content dictionary grouped by APAR/non-APAR

### Structure
The V2 god-class is split into focused, independently testable collaborators — validation, data transform, org lookup, content lookup, ElasticSearch and enrichment — orchestrated by `CbPlanServiceV3Impl`.

### Caching
- `CbPlanCacheMgrV3`: two-tier Caffeine cache (year-scoped lookups + per-planId), configurable TTL/size, with batched Cassandra reads instead of per-ID queries.
- `/user/dictionary` results cached in Redis per user+planYear with explicit TTL.
- User basic profile read from the shared `user:basicProfile:{userId}` key written by cb-ext-userprofile-service, falling back to Cassandra on a miss.
- Content metadata reuses the `extended_read_content_{id}` key, falling back to the extended/external content read APIs.

### Publish durability
Publish uses the pre-commit-validator + rollback overload of `updateRecord`, so the ES document is written before the Cassandra commit and rolled back if the commit fails. Unrecoverable divergence is logged as `ES_CASSANDRA_DIVERGENCE`.

### Config
New `cbplan.enriched.content.fields`, `cb.plan.v3.*` and `cassandra.query.limit.*` properties; `planYear` added to the CB Plan ES mapping; V3 table names, error messages, request/response keys and cache-key prefixes extracted into `Constants`.

### Tests
254 unit tests (JUnit 5 + Mockito), all passing — all 7 endpoints, service happy/error paths, `CbPlanCacheMgrV3` cache and batching behaviour, collaborator services, DTOs, and `CbPlanYearUtil` financial-year edge cases.