### PR TITLE
KB-15116 | BE|Testing| CA/APAR Code Fixes - Creation flow APIs - Issues while Dev Testing

### DIFF
--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanElasticSearchServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanElasticSearchServiceV3Impl.java
@@ -97,6 +97,23 @@ public class CbPlanElasticSearchServiceV3Impl {
                 sanitized.put(entry.getKey(), value);
             }
         }
+        alignKeysWithEsSchema(sanitized);
         return sanitized;
+    }
+
+    /**
+     * Renames Cassandra column keys to the camelCase field names declared in the
+     * ElasticSearch required-fields schema.
+     * EsUtilService drops any document key absent from that schema, so a key whose
+     * case differs from the schema is silently discarded instead of being indexed.
+     * The plan year is stored in Cassandra as "planyear" but declared in the schema
+     * and index mapping as "planYear";
+     *
+     * @param sanitized document being prepared for indexing, mutated in place
+     */
+    private void alignKeysWithEsSchema(Map<String, Object> sanitized) {
+        if (sanitized.containsKey(Constants.PLAN_YEAR)) {
+            sanitized.put(Constants.REQUEST_PARAM_PLAN_YEAR, sanitized.remove(Constants.PLAN_YEAR));
+        }
     }
 }

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanServiceV3Impl.java
@@ -248,7 +248,7 @@ public class CbPlanServiceV3Impl implements CbPlanServiceV3 {
     private void handleUpdateOfDraftCbPlan(ApiRequest request, String userId, String userOrgId,
                                            Map<String, Object> updatedCbPlan, Map<String, Object> existingCbPlan,
                                            boolean isCCA, ApiResponse response) throws JsonProcessingException {
-        List<String> validations = requestValidator.validateCbPlanCreateRequest(request, isCCA, userOrgId, false);
+        List<String> validations = requestValidator.validateCbPlanCreateRequestV3(request, isCCA, userOrgId, false);
         if (CollectionUtils.isNotEmpty(validations)) {
             response.getParams().setStatus(Constants.FAILED);
             response.getParams().setErr(mapper.writeValueAsString(validations));

--- a/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanValidationServiceV3Impl.java
+++ b/src/main/java/com/igot/cb/cbplan/service/impl/CbPlanValidationServiceV3Impl.java
@@ -101,7 +101,7 @@ public class CbPlanValidationServiceV3Impl {
      */
     public boolean validateRequest(ApiRequest request, boolean isCCA, String userOrgId, ApiResponse response) {
         try {
-            List<String> validations = requestValidator.validateCbPlanCreateRequest(request, isCCA, userOrgId, false);
+            List<String> validations = requestValidator.validateCbPlanCreateRequestV3(request, isCCA, userOrgId, false);
             if (CollectionUtils.isNotEmpty(validations)) {
                 response.getParams().setStatus(Constants.FAILED);
                 response.getParams().setErr(mapper.writeValueAsString(validations));

--- a/src/main/java/com/igot/cb/util/RequestValidator.java
+++ b/src/main/java/com/igot/cb/util/RequestValidator.java
@@ -22,6 +22,8 @@ import jakarta.validation.ValidatorFactory;
 public class RequestValidator {
     private final ObjectMapper mapper = new ObjectMapper();
     private final CbExtServerProperties cbExtServerProperties;
+    private static final String ERR_VALIDATION_PREFIX = "Validation Error: ";
+    private static final Validator V3_VALIDATOR = buildV3Validator();
 
     public RequestValidator(CbExtServerProperties cbExtServerProperties) {
         this.cbExtServerProperties = cbExtServerProperties;
@@ -217,5 +219,61 @@ public class RequestValidator {
         }
 
         return errors;
+    }
+
+    /**
+     * Builds the bean validator used by the V3 flows.
+     * The factory is closed as soon as the validator has been obtained; holding it open
+     * for the lifetime of the bean would leak it, and the validator does not need it.
+     *
+     * @return validator for CB Plan V3 payloads
+     */
+    private static Validator buildV3Validator() {
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            return validatorFactory.getValidator();
+        }
+    }
+
+    /**
+     * Validates a CB Plan create/update request for the V3 APIs.
+     * Behaves like {@link #validateCbPlanCreateRequest} but reports which field failed.
+     * V1/V2 flows are unaffected and continue to use the original method.
+     *
+     * @param request       API request
+     * @param isCCA         whether the logged in org is CCA
+     * @param loggedInOrgId logged in user's organization ID
+     * @param isAdmin       whether the logged in user is an admin
+     * @return list of validation errors, empty if the request is valid
+     */
+    public List<String> validateCbPlanCreateRequestV3(ApiRequest request, boolean isCCA, String loggedInOrgId,
+                                                      boolean isAdmin) {
+        Map<String, Object> rawRequest = (Map<String, Object>) request.getRequest();
+        List<String> errors = validateCbPlanRequestV3(rawRequest);
+        if (CollectionUtils.isNotEmpty(errors)) {
+            return errors;
+        }
+        return validateContextData(rawRequest, isCCA, loggedInOrgId, null, isAdmin);
+    }
+
+    /**
+     * Validates mandatory CB Plan fields for the V3 APIs.
+     * Each violation names the offending field and the list is sorted so the same
+     * payload always yields the same error order.
+     *
+     * @param request raw request map
+     * @return sorted list of validation errors, empty if the request is valid
+     */
+    public List<String> validateCbPlanRequestV3(Map<String, Object> request) {
+        CbPlanDto cbPlanDto = mapper.convertValue(request, CbPlanDto.class);
+        if (Objects.isNull(cbPlanDto.getIsApar())) {
+            cbPlanDto.setIsApar(false);
+        }
+        request.put(Constants.IS_APAR, cbPlanDto.getIsApar());
+        List<String> validationErrors = new ArrayList<>();
+        for (ConstraintViolation<CbPlanDto> violation : V3_VALIDATOR.validate(cbPlanDto)) {
+            validationErrors.add(ERR_VALIDATION_PREFIX + violation.getPropertyPath() + " " + violation.getMessage());
+        }
+        Collections.sort(validationErrors);
+        return validationErrors;
     }
 }

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanServiceV3ImplTest.java
@@ -147,7 +147,7 @@ class CbPlanServiceV3ImplTest {
     @Test
     void testCreateCbPlanSuccess() {
         mockValidUserAndOrg(false);
-        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+        when(requestValidator.validateCbPlanCreateRequestV3(any(), anyBoolean(), anyString(), anyBoolean()))
                 .thenReturn(List.of());
         when(cassandraOperation.insertRecord(anyString(), anyString(), anyMap())).thenReturn(cassandraInsertSuccess());
         Map<String, Object> requestMap = new HashMap<>();
@@ -179,7 +179,7 @@ class CbPlanServiceV3ImplTest {
     @Test
     void testCreateCbPlanFailsOnValidationErrors() {
         mockValidUserAndOrg(false);
-        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+        when(requestValidator.validateCbPlanCreateRequestV3(any(), anyBoolean(), anyString(), anyBoolean()))
                 .thenReturn(List.of("name is required"));
         ApiResponse response = cbPlanService.createCbPlan(apiRequest(new HashMap<>()), ORG_ID, TOKEN);
         assertEquals(Constants.FAILED, response.getParams().getStatus());
@@ -190,7 +190,7 @@ class CbPlanServiceV3ImplTest {
     @Test
     void testCreateCbPlanFailsWhenInsertFails() {
         mockValidUserAndOrg(false);
-        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+        when(requestValidator.validateCbPlanCreateRequestV3(any(), anyBoolean(), anyString(), anyBoolean()))
                 .thenReturn(List.of());
         ApiResponse insertFailed = new ApiResponse();
         insertFailed.put(Constants.RESPONSE, Constants.FAILED);
@@ -249,7 +249,7 @@ class CbPlanServiceV3ImplTest {
         existingCbPlan.put(Constants.CREATED_BY, USER_ID);
         existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
         mockExistingPlan(existingCbPlan);
-        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+        when(requestValidator.validateCbPlanCreateRequestV3(any(), anyBoolean(), anyString(), anyBoolean()))
                 .thenReturn(List.of());
         when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
                 .thenReturn(Map.of(Constants.RESPONSE, Constants.SUCCESS));
@@ -265,7 +265,7 @@ class CbPlanServiceV3ImplTest {
         existingCbPlan.put(Constants.CREATED_BY, USER_ID);
         existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
         mockExistingPlan(existingCbPlan);
-        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+        when(requestValidator.validateCbPlanCreateRequestV3(any(), anyBoolean(), anyString(), anyBoolean()))
                 .thenReturn(List.of("invalid field"));
         ApiResponse response = cbPlanService.updateCbPlan(requestWithPlanId(), ORG_ID, TOKEN, List.of());
         assertEquals(Constants.FAILED, response.getParams().getStatus());
@@ -280,7 +280,7 @@ class CbPlanServiceV3ImplTest {
         existingCbPlan.put(Constants.CREATED_BY, USER_ID);
         existingCbPlan.put(Constants.STATUS, Constants.DRAFT);
         mockExistingPlan(existingCbPlan);
-        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+        when(requestValidator.validateCbPlanCreateRequestV3(any(), anyBoolean(), anyString(), anyBoolean()))
                 .thenReturn(List.of());
         when(cassandraOperation.updateRecord(anyString(), anyString(), anyMap(), anyMap()))
                 .thenReturn(Map.of(Constants.RESPONSE, Constants.FAILED));

--- a/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanValidationServiceV3ImplTest.java
+++ b/src/test/java/com/igot/cb/cbplan/service/impl/CbPlanValidationServiceV3ImplTest.java
@@ -129,7 +129,7 @@ class CbPlanValidationServiceV3ImplTest {
 
     @Test
     void testValidateRequestPassesWhenNoValidationErrors() {
-        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+        when(requestValidator.validateCbPlanCreateRequestV3(any(), anyBoolean(), anyString(), anyBoolean()))
                 .thenReturn(List.of());
         assertTrue(validationService.validateRequest(new ApiRequest(), true, ORG_ID, new ApiResponse()));
     }
@@ -137,7 +137,7 @@ class CbPlanValidationServiceV3ImplTest {
     @Test
     void testValidateRequestFailsWithValidationErrors() {
         ApiResponse response = new ApiResponse();
-        when(requestValidator.validateCbPlanCreateRequest(any(), anyBoolean(), anyString(), anyBoolean()))
+        when(requestValidator.validateCbPlanCreateRequestV3(any(), anyBoolean(), anyString(), anyBoolean()))
                 .thenReturn(List.of("name is required"));
         assertFalse(validationService.validateRequest(new ApiRequest(), true, ORG_ID, response));
         assertEquals(Constants.FAILED, response.getParams().getStatus());


### PR DESCRIPTION
Two defects found while dev testing the CB Plan V3 APIs.

**planYear missing from ElasticSearch** - the plan map keys the year as `planyear` (the Cassandra column name) but the ES schema and index mapping declare `planYear`. EsUtilService drops any key absent from the schema, so the field was silently discarded - present in Cassandra, absent in ES. Fixed by renaming the key to the schema's camelCase form before indexing, covering the create, draft-update and archive paths. Constants.PLAN_YEAR is left as-is because CbPlanCacheMgr (V1/V2) uses it for Cassandra lookups.

**V3 validation errors did not name the failing field** - a payload missing mandatory fields returned five identical "must not be null"/"must not be blank" messages in non-deterministic order. Added validateCbPlanCreateRequestV3 / validateCbPlanRequestV3 which prefix each violation with the field and sort the result; the existing validateCbPlanRequest is untouched so V1/V2 error strings are unchanged, and only the two V3 call sites were repointed.

    before: Validation Error: must not be blank
    after:  Validation Error: name must not be blank